### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @hg-pyun @taehwanno @simsim0709 @gnujoow @b9words @taggon @MaxKim-J @eomttt @goofcode


### PR DESCRIPTION
원활한 리뷰를 위해서 maintainer들을 CODEOWNER에 포함시키고, main브랜치 프로텍션 옵션에서 아래 규칙을 추가합니다.

![image](https://user-images.githubusercontent.com/10865414/235351047-84543549-ab76-443e-b1bf-2838ca863143.png)


**참고**
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners



@hg-pyun @taehwanno @simsim0709 @gnujoow @b9words @taggon @MaxKim-J @eomttt @goofcode