### PR TITLE
FIX: ci-check error

### DIFF
--- a/src/content/reference/react/PureComponent.md
+++ b/src/content/reference/react/PureComponent.md
@@ -50,8 +50,7 @@ class Greeting extends PureComponent {
 
 ## 사용법 {/*usage*/}
 
-### 클래스 컴포넌트에서 불필요한 재 렌더링 건너뛰기
-{/*skipping-unnecessary-re-renders-for-class-components*/}
+### 클래스 컴포넌트에서 불필요한 재 렌더링 건너뛰기 {/*skipping-unnecessary-re-renders-for-class-components*/}
 
 리액트는 일반적으로 부모가 다시 렌더링 될 때마다 자식 컴포넌트도 다시 렌더링 합니다. 하지만 `PureComponent`를 extend 하여 새 props 및 state가 이전 props 및 state와 같다면 부모가 다시 렌더링 되더라도 자식 컴포넌트는 다시 렌더링 되지 않도록 [Class component](/reference/react/Component)를 최적화할 수 있습니다.
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

#637 에서 보고된 CI 오류를 수정합니다.

원인은 PureComponent 문서에서 헤더의 아이디를 설정하는 구문이 한 줄 아래로 내려가 있어서 '아이디가 없는' 헤더가 발생했고 이에 따라 모든 헤더에 아이디가 있도록 설정한 규칙 검사에서 오류가 발생한 것입니다.

Resolves #637 