### PR TITLE
Translate: react-18-upgrade-guide and fix translation in hydrateRoot

### DIFF
--- a/src/components/Layout/HomeContent.js
+++ b/src/components/Layout/HomeContent.js
@@ -158,10 +158,10 @@ export function HomeContent() {
             <Header>컴포넌트를 사용하여 사용자 인터페이스 만들기</Header>
             <Para>
               React를 사용하면 컴포넌트라고 불리는 조각들을 사용하여 사용자
-              인터페이스를 만들 수 있습니다.
-              <Code>Thumbnail</Code>, <Code>LikeButton</Code>, 그리고{' '}
-              <Code>Video</Code> 같은 컴포넌트를 만들 수 있습니다. 그런 다음
-              전체 화면, 페이지 및 앱에서 이들을 결합할 수 있습니다.
+              인터페이스를 만들 수 있습니다. <Code>Thumbnail</Code>,{' '}
+              <Code>LikeButton</Code>, 그리고 <Code>Video</Code> 같은 컴포넌트를
+              만들 수 있습니다. 그런 다음 전체 화면, 페이지 및 앱에서 이들을
+              결합할 수 있습니다.
             </Para>
           </Center>
           <FullBleed>
@@ -235,7 +235,7 @@ export function HomeContent() {
             <Para>
               React는 라이브러리입니다. 컴포넌트를 함께 묶을 수 있지만, 라우팅과
               데이터를 가져오는 방법을 규정하지는 않습니다. React로 앱을
-              만들려면, <Link href="https://nextjs.org">Next.js</Link> 또는
+              만들려면, <Link href="https://nextjs.org">Next.js</Link> 또는{' '}
               <Link href="https://remix.run">Remix</Link> 같은 풀스택 React
               프레임워크를 추천합니다.
             </Para>
@@ -285,12 +285,12 @@ export function HomeContent() {
                         웹에 충실하기
                       </h4>
                       <p className="lg:text-xl leading-normal text-secondary">
-                        사람들은 웹이 빠르게 로드되길 기대합니다. 서버에서 React
-                        를 사용하면 데이터를 가져오는 동안 HTML을 스트리밍하여
-                        JavaScript 코드가 로드되기 전에 남은 내용을 점진적으로
-                        채울 수 있습니다. 클라이언트에서 React는 표준 web API를
-                        사용하여 렌더링 중에도 UI를 반응적으로 유지할 수
-                        있습니다.
+                        사람들은 웹이 빠르게 로드되길 기대합니다. 서버에서
+                        React를 사용하면 데이터를 가져오는 동안 HTML을
+                        스트리밍하여 JavaScript 코드가 로드되기 전에 남은 내용을
+                        점진적으로 채울 수 있습니다. 클라이언트에서 React는 표준
+                        web API를 사용하여 렌더링 중에도 UI를 반응적으로 유지할
+                        수 있습니다.
                       </p>
                     </div>
                   </div>
@@ -375,14 +375,14 @@ export function HomeContent() {
                           느껴지기를 원합니다.{' '}
                           <Link href="https://reactnative.dev">
                             React Native
-                          </Link>{' '}
+                          </Link>
                           와{' '}
                           <Link href="https://github.com/expo/expo">Expo</Link>
                           를 사용하면 React를 통하여 Android, iOS 등을 위한 앱을
-                          빌드 할 수 있습니다. UI들이 native 이기때문에 진짜
-                          native 처럼 보여집니다. 이것은 web view 가 아닙니다.
-                          React 컴포넌트들은 실제 Android, iOS 플랫폼에서
-                          제공하는 view 를 렌더링합니다.
+                          빌드할 수 있습니다. UI들이 native이기 때문에 진짜
+                          native처럼 보입니다. 이것은 web view가 아닙니다. React
+                          컴포넌트들은 실제 Android, iOS 플랫폼에서 제공하는
+                          view를 렌더링합니다.
                         </p>
                       </div>
                     </div>
@@ -464,7 +464,7 @@ export function HomeContent() {
           <div className="w-full">
             <div className="mx-auto flex flex-col max-w-4xl">
               <Center>
-                <Header>수백만명이 있는 커뮤니티</Header>
+                <Header>수백만 명이 있는 커뮤니티</Header>
                 <Para>
                   여러분은 혼자가 아닙니다. 200만 명이 넘는 개발자들이 React
                   문서를 매달 방문합니다. React는 사람들과 팀이 동의할 수 있는

--- a/src/content/blog/2022/03/08/react-18-upgrade-guide.md
+++ b/src/content/blog/2022/03/08/react-18-upgrade-guide.md
@@ -8,7 +8,7 @@ title: "React 18로 업그레이드하는 방법"
 
 <Intro>
 
-React 18은 [릴리스 노트](/blog/2022/03/29/react-v18)에서 언급한 대로, 새로운 동시성 렌더러를 도입하여 기존 애플리케이션에 점진적으로 적용할 계획입니다. 이 글에서는 React 18로 업그레이드하는 방법을 단계별로 소개하겠습니다.
+React 18은 [릴리스 노트](/blog/2022/03/29/react-v18)에서 언급한 대로 새로운 동시성 렌더러를 도입하여 기존 애플리케이션에 점진적으로 적용할 계획입니다. 이 글에서는 React 18로 업그레이드하는 방법을 단계별로 소개하겠습니다.
 
 React 18로 업그레이드하는 과정에서 발생하는 [문제를 알려주세요](https://github.com/facebook/react/issues/new/choose).
 
@@ -24,13 +24,13 @@ React Native 사용자의 경우, React 18은 React Native의 향후 버전에 �
 
 ## 설치 {/*installing*/}
 
-최신 버전의 React를 설치하기 위해, 다음 명령어를 입력하세요.
+최신 버전의 React를 설치하기 위해 다음 명령어를 입력하세요.
 
 ```bash
 npm install react react-dom
 ```
 
-혹은 yarn을 사용한다면, 다음 명령어를 입력하세요.
+혹은 yarn을 사용한다면 다음 명령어를 입력하세요.
 
 ```bash
 yarn add react react-dom
@@ -57,7 +57,7 @@ render(<App tab="home" />, container);
 // 변경 후
 import { createRoot } from 'react-dom/client';
 const container = document.getElementById('app');
-const root = createRoot(container); // createRoot(container!) if you use TypeScript
+const root = createRoot(container); // 만약 TypeScript를 사용한다면 createRoot(container!)
 root.render(<App tab="home" />);
 ```
 
@@ -71,7 +71,7 @@ unmountComponentAtNode(container);
 root.unmount();
 ```
 
-또한, Suspense를 사용할 때 일반적으로 기대한 결과가 나오지 않기 때문에 콜백 함수를 렌더링 메서드에서 제거했습니다.
+또한 Suspense를 사용할 때 일반적으로 기대한 결과가 나오지 않기 때문에 콜백 함수를 렌더링 메서드에서 제거했습니다.
 
 ```js
 // 변경 전
@@ -131,10 +131,10 @@ const root = hydrateRoot(container, <App tab="home" />);
 
 * `renderToNodeStream`: **더 이상 사용되지 않음 ⛔️️**
 
-대신에, Node 환경에서 스트리밍하려면 다음 API를 사용하세요.
+대신에 Node 환경에서 스트리밍하려면 다음 API를 사용하세요.
 * `renderToPipeableStream`: **새로 추가됨 ✨**
 
-더불어, Deno나 Cloudflare workers와 같은 최신 런타임 환경에서 Suspense를 활용하여 스트리밍 SSR를 지원하기 위해 새로운 API를 도입합니다.
+더불어 Deno나 Cloudflare workers와 같은 최신 런타임 환경에서 Suspense를 활용하여 스트리밍 SSR를 지원하기 위해 새로운 API를 도입합니다.
 * `renderToReadableStream`: **새로 추가됨 ✨**
 
 다음 API들은 계속 작동되긴 하지만, Suspense 지원이 제한될 것입니다.
@@ -167,7 +167,6 @@ interface MyButtonProps {
 React 18은 자동으로 더 많은 batching을 수행하여 놀라운 성능 향상을 이뤘습니다. Batching이란 더 나은 성능을 위해 여러 개의 상태 업데이트를 단 한 번의 리렌더링으로 처리하는 것을 말합니다. React 18 이전에는 React 이벤트 핸들러 내에서의 상태 업데이트만 batching을 수행해 왔습니다. 그러나 프로미스, setTimeout, 네이티브 이벤트 핸들러 또는 다른 이벤트들은 React에서 기본적으로 batching을 수행하지 않았죠. 다음 예시를 확인하세요.
 
 ```js
-// Before React 18 only React events were batched
 // React 18 이전에는 오직 React 이벤트들만 batch되었습니다.
 
 function handleClick() {
@@ -239,7 +238,6 @@ React 18 워킹 그룹은 스타일이나 외부 저장 장치와 같은 특정 
 
 React 18은 이러한 문제를 시각적으로 보여주기 위해 Strict 모드에 개발 전용 검사를 새롭게 도입합니다. 이 검사는 컴포넌트가 처음 마운트될 때 자동으로 언마운트한 다음, 이전 상태를 복원하면서 다시 마운트할 것입니다.
 
-Before this change, React would mount the component and create the effects:
 이 업데이트 이전에는 React가 다음과 같이 컴포넌트를 마운트하고 effect를 생성했습니다.
 
 ```
@@ -248,7 +246,7 @@ Before this change, React would mount the component and create the effects:
     * 이펙트 effect가 생성됩니다.
 ```
 
-React 18의 Strict 모드에서는, 개발 전용 모드에서 React가 컴포넌트를 마운트 해제하고 다시 마운트하는 것을 실험합니다.
+React 18의 Strict 모드에서는 개발 전용 모드에서 React가 컴포넌트를 마운트 해제하고 다시 마운트하는 것을 실험합니다.
 
 ```
 * React가 컴포넌트를 마운트합니다.
@@ -285,7 +283,7 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 React에 `act`가 필요 없다고 알리려면 해당 변수를 `false`로 설정할 수 있습니다. 이렇게 하면 전체 브라우저 환경을 시뮬레이션하는 종단 간 테스트에 유용하게 사용할 수 있습니다.
 
-결국에는, 테스트 라이브러리가 이를 자동으로 설정해줄 것으로 예상합니다. 예를 들어, [React Testing Library의 다음 버전은 추가적인 설정 없이도 React 18을 지원하는 기능이 내장되어 있습니다](https://github.com/testing-library/react-testing-library/issues/509#issuecomment-917989936).
+결국에는 테스트 라이브러리가 이를 자동으로 설정해줄 것으로 예상합니다. 예를 들어, [React Testing Library의 다음 버전은 추가적인 설정 없이도 React 18을 지원하는 기능이 내장되어 있습니다](https://github.com/testing-library/react-testing-library/issues/509#issuecomment-917989936).
 
 [`act` 테스트 API와 유관 변경 사항에 대한 추가 정보](https://github.com/reactwg/react-18/discussions/102)는 워킹 그룹에서 확인할 수 있습니다.
 
@@ -319,7 +317,7 @@ Internet Explorer를 지원해야 하는 경우 React 17을 사용하는 것을 
 * **이제 컴포넌트들이 `undefined`를 렌더링할 수 있습니다.** React는 더 이상 컴포넌트에서 `undefined`를 반환할 때 경고하지 않습니다. 이렇게 함으로써 컴포넌트는 컴포넌트 트리의 중간에 허용된 값과 일관된 값을 반환하게 됩니다. JSX 앞에 `return` 문을 빼먹는 실수와 같은 문제를 방지하기 위해 린터를 사용하는 것을 권장합니다.
 * **테스트에서 `act` 경고는 이제 선택 사항입니다.** 종단 간 테스트를 실행하는 경우 `act` 경고 메시지는 불필요합니다. 이 경고 메시지가 쓸모 있는 [유닛 테스트에서만 활성화할 수 있도록](https://github.com/reactwg/react-18/discussions/102) 만들었습니다.
 * **이제 마운트가 해제된 컴포넌트에서 `setState` 관련 경고가 나타나지 않습니다.** 이전에는 `setState`를 마운트가 해제된 컴포넌트에서 호출할 때 메모리 누수에 대한 경고가 표시되었습니다. 이 경고는 구독을 위해 추가되었지만, 대부분의 경우 상태 설정에 문제가 없을 때 이 경고를 마주치게 되어 코드를 더 나빠지게 만드는 대안을 찾아야 했습니다. React 18에서는 이 경고를 [제거했습니다](https://github.com/facebook/react/pull/22114).
-* **더 이상 콘솔 로그를 억제하지 않습니다.** Strict 모드를 사용할 때, React는 예기치 않은 부작용을 감지하기 위해 각 컴포넌트를 두 번 렌더링합니다. React 17에서는 두 번째 렌더링의 콘솔 로그를 억제하여 로그를 더 쉽게 읽을 수 있게 했습니다. 그러나 [커뮤니티의 피드백](https://github.com/facebook/react/issues/21783)에 따라 이 억제를 제거했습니다. 이제 React DevTools가 설치되어 있다면 두 번째 로그의 렌더링이 회색으로 표시되며, 완전히 억제하는 옵션도 사용할 수 있습니다. (기본적으로 꺼져 있음)
+* **더 이상 콘솔 로그를 억제하지 않습니다.** Strict 모드를 사용할 때 React는 예기치 않은 부작용을 감지하기 위해 각 컴포넌트를 두 번 렌더링합니다. React 17에서는 두 번째 렌더링의 콘솔 로그를 억제하여 로그를 더 쉽게 읽을 수 있게 했습니다. 그러나 [커뮤니티의 피드백](https://github.com/facebook/react/issues/21783)에 따라 이 억제를 제거했습니다. 이제 React DevTools가 설치되어 있다면 두 번째 로그의 렌더링이 회색으로 표시되며 완전히 억제하는 옵션도 사용할 수 있습니다. (기본적으로 꺼져 있음)
 * **메모리 사용을 개선했습니다.** React는 이제 마운트가 해제될 때 더 많은 내부 필드를 정리하여 코드에 존재할 수 있는 수정되지 않은 메모리 누수의 영향을 덜 심하게 만듭니다.
 
 ### React DOM 서버 {/*react-dom-server*/}

--- a/src/content/blog/2022/03/08/react-18-upgrade-guide.md
+++ b/src/content/blog/2022/03/08/react-18-upgrade-guide.md
@@ -8,7 +8,7 @@ title: "React 18로 업그레이드하는 방법"
 
 <Intro>
 
-React 18은 [릴리스 노트](/blog/2022/03/29/react-v18)에서 언급한 대로, 새로운 동시성 렌더러를 도입하여 기존 어플리케이션에 점진적으로 적용할 계획입니다. 이 글에서는 React 18로 업그레이드하는 방법을 단계별로 소개하겠습니다.
+React 18은 [릴리스 노트](/blog/2022/03/29/react-v18)에서 언급한 대로, 새로운 동시성 렌더러를 도입하여 기존 애플리케이션에 점진적으로 적용할 계획입니다. 이 글에서는 React 18로 업그레이드하는 방법을 단계별로 소개하겠습니다.
 
 React 18로 업그레이드하는 과정에서 발생하는 [문제를 알려주세요](https://github.com/facebook/react/issues/new/choose).
 
@@ -16,7 +16,7 @@ React 18로 업그레이드하는 과정에서 발생하는 [문제를 알려주
 
 <Note>
 
-React Native 사용자의 경우, React 18은 React Native의 향후 버전에 탑재될 것입니다. 이는 새로운 기능을 활용하기 위해 React 18이 이 글에서 소개되는 새로운 React Native 아키텍처에 의존하기 때문입니다. 자세한 정보는 [React Conference 키노트](https://www.youtube.com/watch?v=FZ0cG47msEk&t=1530s)를 확인해주세요.
+React Native 사용자의 경우, React 18은 React Native의 향후 버전에 탑재될 것입니다. 이는 새로운 기능을 활용하기 위해 React 18이 이 글에서 소개되는 새로운 React Native 아키텍처에 의존하기 때문입니다. 자세한 정보는 [React Conf 키노트](https://www.youtube.com/watch?v=FZ0cG47msEk&t=1530s)를 확인해주세요.
 
 </Note>
 
@@ -144,7 +144,7 @@ const root = hydrateRoot(container, <App tab="home" />);
 마지막으로, 이 API는 앞으로도 이메일을 렌더링할 예정입니다.
 * `renderToStaticNodeStream`
 
-서버 렌더링 API 변경사항과 관련된 자세한 정보는 작업 중인 그룹 포스트 [Upgrading to React 18 on the server](https://github.com/reactwg/react-18/discussions/22), [deep dive on the new Suspense SSR Architecture](https://github.com/reactwg/react-18/discussions/37), 그리고 React Conf 2021에서 [Shaundai Person](https://twitter.com/shaundai)이 발표한 [Streaming Server Rendering with Suspense](https://www.youtube.com/watch?v=pj5N-Khihgc)에서 확인할 수 있습니다.
+서버 렌더링 API 변경 사항과 관련된 자세한 정보는 작업 중인 그룹 포스트 [Upgrading to React 18 on the server](https://github.com/reactwg/react-18/discussions/22), [deep dive on the new Suspense SSR Architecture](https://github.com/reactwg/react-18/discussions/37), 그리고 React Conf 2021에서 [Shaundai Person](https://twitter.com/shaundai)이 발표한 [Streaming Server Rendering with Suspense](https://www.youtube.com/watch?v=pj5N-Khihgc)에서 확인할 수 있습니다.
 
 ## TypeScript 사용 시 타입 작성에 대한 업데이트 {/*updates-to-typescript-definitions*/}
 
@@ -292,7 +292,7 @@ React에 `act`가 필요 없다고 알리려면 해당 변수를 `false`로 설�
 ## Internet Explorer 지원 중단 {/*dropping-support-for-internet-explorer*/}
 
 이번 배포에서 React는 [2022년 6월 15일에 지원이 종료되는](https://blogs.windows.com/windowsexperience/2021/05/19/the-future-of-internet-explorer-on-windows-10-is-in-microsoft-edge) Internet Explorer의 지원을 중단합니다.
-이러한 변경 사항을 적용하는 이유는 React 18에서 도입된 새로운 기능들이 IE에서 적절하게 [폴리 필링](https://developer.mozilla.org/ko/docs/Glossary/Polyfill) 할 수 없는 마이크로태스크와 같은 모던 브라우저 기능을 사용하기 때문입니다.
+이러한 변경 사항을 적용하는 이유는 React 18에서 도입된 새로운 기능들이 IE에서 적절하게 폴리필 할 수 없는 마이크로 태스크와 같은 모던 브라우저 기능을 사용하기 때문입니다.
 
 Internet Explorer를 지원해야 하는 경우 React 17을 사용하는 것을 권장합니다.
 
@@ -304,13 +304,13 @@ Internet Explorer를 지원해야 하는 경우 React 17을 사용하는 것을 
 * `react-dom`: `ReactDOM.renderSubtreeIntoContainer`가 더 이상 사용되지 않습니다.
 * `react-dom/server`: `ReactDOMServer.renderToNodeStream`이 더 이상 사용되지 않습니다.
 
-## 이 밖의 놀라운 변화 {/*other-breaking-changes*/}
+## 이 밖의 획기적인 변화 {/*other-breaking-changes*/}
 
-* **Consistent useEffect timing**: React now always synchronously flushes effect functions if the update was triggered during a discrete user input event such as a click or a keydown event. Previously, the behavior wasn't always predictable or consistent.
-* **Stricter hydration errors**: Hydration mismatches due to missing or extra text content are now treated like errors instead of warnings. React will no longer attempt to "patch up" individual nodes by inserting or deleting a node on the client in an attempt to match the server markup, and will revert to client rendering up to the closest `<Suspense>` boundary in the tree. This ensures the hydrated tree is consistent and avoids potential privacy and security holes that can be caused by hydration mismatches.
-* **Suspense trees are always consistent:** If a component suspends before it's fully added to the tree, React will not add it to the tree in an incomplete state or fire its effects. Instead, React will throw away the new tree completely, wait for the asynchronous operation to finish, and then retry rendering again from scratch. React will render the retry attempt concurrently, and without blocking the browser.
-* **Layout Effects with Suspense**: When a tree re-suspends and reverts to a fallback, React will now clean up layout effects, and then re-create them when the content inside the boundary is shown again. This fixes an issue which prevented component libraries from correctly measuring layout when used with Suspense.
-* **New JS Environment Requirements**: React now depends on modern browsers features including `Promise`, `Symbol`, and `Object.assign`. If you support older browsers and devices such as Internet Explorer which do not provide modern browser features natively or have non-compliant implementations, consider including a global polyfill in your bundled application.
+* **일관된 useEffect 타이밍**: click이나 keydown 이벤트와 같은 개별적인 사용자 입력 이벤트 중에 업데이트가 트리거된 경우 React는 항상 동기적으로 이펙트 함수를 플러시합니다. 이전에는 동작이 언제나 예측 가능하거나 일관적이지 않았습니다.
+* **Hydration 오류 강화**: 텍스트 콘텐츠가 누락되거나 추가되어 Hydration 불일치가 발생하는 경우 이제 경고가 아닌 오류로 처리됩니다. React는 더 이상 서버 마크업과 일치시키기 위해 클라이언트에서 노드를 삽입하거나 삭제하여 개별 노드를 "패치 업" 하려고 시도하지 않으며, 트리에서 가장 가까운 `<Suspense>` 바운더리까지 클라이언트 렌더링으로 되돌립니다. 이렇게 하면 Hydration 트리의 일관성을 유지하고 Hydration 불일치로 인해 발생할 수 있는 잠재적인 개인정보 보호 및 보안 허점을 방지할 수 있습니다.
+* **항상 일관성을 유지하는 Suspense 트리**: 컴포넌트가 트리에 완전히 추가되기 전에 일시 중단되면 React는 불완전한 상태로 트리에 추가하거나 그 이펙트를 실행하지 않습니다. 대신 React는 새 트리를 완전히 버리고 비동기 작업이 완료될 때까지 기다린 다음 처음부터 다시 렌더링을 시도합니다. React는 브라우저를 블로킹하지 않고 다시 시도해 동시에 렌더링합니다.
+* **Suspense가 있는 레이아웃 효과**: 트리가 다시 일시 중단되고 fallback으로 되돌아갈 때, React는 레이아웃 효과를 정리(clean-up)한 후 경계 안의 콘텐츠가 다시 표시될 때 레이아웃 효과를 다시 생성합니다. 이는 Suspense와 함께 사용할 때 컴포넌트 라이브러리가 레이아웃을 올바르게 측정하지 못하던 문제를 해결합니다.
+* **새로운 JS 환경 요구 사항**: React는 이제 `Promise`, `Symbol`, `Object.assign`을 포함한 최신 브라우저 기능에 의존합니다. 최신 브라우저 기능을 기본적으로 제공하지 않거나 호환되지 않는 구현이 있는 Internet Explorer와 같은 구형 브라우저 및 기기를 지원하는 경우 번들된 애플리케이션에 전역 폴리필을 포함하는 것을 고려하세요.
 
 ## 이 밖의 주목할 만한 변화 {/*other-notable-changes*/}
 
@@ -320,14 +320,13 @@ Internet Explorer를 지원해야 하는 경우 React 17을 사용하는 것을 
 * **테스트에서 `act` 경고는 이제 선택 사항입니다.** 종단 간 테스트를 실행하는 경우 `act` 경고 메시지는 불필요합니다. 이 경고 메시지가 쓸모 있는 [유닛 테스트에서만 활성화할 수 있도록](https://github.com/reactwg/react-18/discussions/102) 만들었습니다.
 * **이제 마운트가 해제된 컴포넌트에서 `setState` 관련 경고가 나타나지 않습니다.** 이전에는 `setState`를 마운트가 해제된 컴포넌트에서 호출할 때 메모리 누수에 대한 경고가 표시되었습니다. 이 경고는 구독을 위해 추가되었지만, 대부분의 경우 상태 설정에 문제가 없을 때 이 경고를 마주치게 되어 코드를 더 나빠지게 만드는 대안을 찾아야 했습니다. React 18에서는 이 경고를 [제거했습니다](https://github.com/facebook/react/pull/22114).
 * **더 이상 콘솔 로그를 억제하지 않습니다.** Strict 모드를 사용할 때, React는 예기치 않은 부작용을 감지하기 위해 각 컴포넌트를 두 번 렌더링합니다. React 17에서는 두 번째 렌더링의 콘솔 로그를 억제하여 로그를 더 쉽게 읽을 수 있게 했습니다. 그러나 [커뮤니티의 피드백](https://github.com/facebook/react/issues/21783)에 따라 이 억제를 제거했습니다. 이제 React DevTools가 설치되어 있다면 두 번째 로그의 렌더링이 회색으로 표시되며, 완전히 억제하는 옵션도 사용할 수 있습니다. (기본적으로 꺼져 있음)
-* **Improved memory usage:** React now cleans up more internal fields on unmount, making the impact from unfixed memory leaks that may exist in your application code less severe.
 * **메모리 사용을 개선했습니다.** React는 이제 마운트가 해제될 때 더 많은 내부 필드를 정리하여 코드에 존재할 수 있는 수정되지 않은 메모리 누수의 영향을 덜 심하게 만듭니다.
 
 ### React DOM 서버 {/*react-dom-server*/}
 
-* **`renderToString`**은 이제 서버에서 서스펜딩할 때 더 이상 오류가 발생하지 않습니다. 대신 가장 가까운 `<Suspense>` 경계에 fallback HTML을 출력하고, 그런 다음 클라이언트에서 동일한 콘텐츠를 다시 렌더링하도록 시도합니다. 여전히 `renderToPipeableStream` 또는 `renderToReadableStream`과 같은 스트리밍 API로 전환하는 것이 좋습니다.
-* **`renderToStaticMarkup`**은 이제 서버에서 서스펜딩할 때 더 이상 오류가 발생하지 않습니다. 대신 가장 가까운 `<Suspense>` 경계에 fallback HTML을 출력합니다.
+* **`renderToString`** 은 이제 서버에서 서스펜딩할 때 더 이상 오류가 발생하지 않습니다. 대신 가장 가까운 `<Suspense>` 경계에 fallback HTML을 출력하고, 그런 다음 클라이언트에서 동일한 콘텐츠를 다시 렌더링하도록 시도합니다. 여전히 `renderToPipeableStream` 또는 `renderToReadableStream`과 같은 스트리밍 API로 전환하는 것이 좋습니다.
+* **`renderToStaticMarkup`** 은 이제 서버에서 서스펜딩할 때 더 이상 오류가 발생하지 않습니다. 대신 가장 가까운 `<Suspense>` 경계에 fallback HTML을 출력합니다.
 
 ## 변경 명세 {/*changelog*/}
 
-[여기에서 전체 변경 명세를](https://github.com/facebook/react/blob/main/CHANGELOG.md) 확인할 수 있습니다.
+[여기에서 전체 변경 명세](https://github.com/facebook/react/blob/main/CHANGELOG.md)를 확인할 수 있습니다.

--- a/src/content/reference/react-dom/client/hydrateRoot.md
+++ b/src/content/reference/react-dom/client/hydrateRoot.md
@@ -4,7 +4,7 @@ title: hydrateRoot
 
 <Intro>
 
-`hydrateRoot`는 [`react-dom/server`](/reference/react-dom/server)를 통해 사전에 만들어진 HTML로 그려진 브라우저 DOM 노드 내부에 리액트 컴포넌트를 렌더링합니다.
+`hydrateRoot`는 [`react-dom/server`](/reference/react-dom/server)를 통해 사전에 만들어진 HTML로 그려진 브라우저 DOM 노드 내부에 React 컴포넌트를 렌더링합니다.
 
 ```js
 const root = hydrateRoot(domNode, reactNode, options?)
@@ -20,7 +20,7 @@ const root = hydrateRoot(domNode, reactNode, options?)
 
 ### `hydrateRoot(domNode, reactNode, options?)` {/*hydrateroot*/}
 
-서버 환경에서 리액트로 앞서 만들어진 HTML에 후에 만들어진 리액트를 `hydrateRoot`를 호출해 "붙입니다".
+서버 환경에서 React로 앞서 만들어진 HTML에 후에 만들어진 React를 `hydrateRoot`를 호출해 "붙입니다".
 
 ```js
 import { hydrateRoot } from 'react-dom/client';
@@ -29,7 +29,7 @@ const domNode = document.getElementById('root');
 const root = hydrateRoot(domNode, reactNode);
 ```
 
-리액트는 `domNode` 내부의 HTML에 붙어, 내부 DOM을 직접 관리할 것입니다. App을 React로 전부 만들었다면 보통은 단 하나의 root component와 함께 `hydrateRoot`를 한 번 호출할 것입니다.
+React는 `domNode` 내부의 HTML에 붙어, 내부 DOM을 직접 관리할 것입니다. App을 React로 전부 만들었다면 보통은 단 하나의 root component와 함께 `hydrateRoot`를 한 번 호출할 것입니다.
 
 [아래 여러 예시를 확인해보세요.](#usage)
 
@@ -37,12 +37,12 @@ const root = hydrateRoot(domNode, reactNode);
 
 * `domNode`: 서버에서 root element로 렌더링된 [DOM element](https://developer.mozilla.org/en-US/docs/Web/API/Element)
 
-* `reactNode`: 앞서 존재하는 HTML에 렌더링하기 위한 "리액트 노드" 입니다. 주로 `ReactDOM Server`의 `renderToPipeableStream(<App />)`와 같은 메소드로 렌더링된  `<App />`같은 JSX 조각들입니다.
+* `reactNode`: 앞서 존재하는 HTML에 렌더링하기 위한 "React 노드" 입니다. 주로 `ReactDOM Server`의 `renderToPipeableStream(<App />)`와 같은 메소드로 렌더링된  `<App />`같은 JSX 조각들입니다.
 
-* **optional** `options`: 리액트 root에 옵션을 주기 위한 객체입니다.
+* **optional** `options`: React root에 옵션을 주기 위한 객체입니다.
 
-  * **optional** `onRecoverableError`: 리액트가 에러에서 자동으로 회복되었을 때 호출하는 콜백함수.
-  * **optional** `identifierPrefix`: 리액트가 ID로 사용하는 접두사로 [`useId`](/reference/react/useId)로 만들어진 값입니다. 같은 페이지에서 여러 root를 사용할 때 충돌을 피할 때 유용하게 사용할 수 있습니다. 서버에서 사용한 값과 반드시 동일한 값이어야 합니다.
+  * **optional** `onRecoverableError`: React가 에러에서 자동으로 회복되었을 때 호출하는 콜백함수.
+  * **optional** `identifierPrefix`: React가 ID로 사용하는 접두사로 [`useId`](/reference/react/useId)로 만들어진 값입니다. 같은 페이지에서 여러 root를 사용할 때 충돌을 피할 때 유용하게 사용할 수 있습니다. 서버에서 사용한 값과 반드시 동일한 값이어야 합니다.
 
 #### Returns {/*returns*/}
 
@@ -51,7 +51,7 @@ const root = hydrateRoot(domNode, reactNode);
 #### Caveats {/*caveats*/}
 
 * `hydrateRoot()`는 서버에서 렌더링된 내용과 후에 렌더링된 내용이 동일할 것을 기대합니다. 따라서 동일하지 않은 부분들은 직접 버그로 취급해주거나 고쳐줘야 합니다.
-* 개발 모드에선, 리액트가 hydration 중에 동일하지 않은 부분에 대해 경고해줍니다. 속성이 동일하지 않을 경우에 해당 속성이 올바르게 적용될 것이라고 보장할 수 없습니다. 모든 markup을 보장하지 않는 것은 성능면에서 중요하기 때문입니다. markup이 동일하지 않는 경우는 드물기 때문에 모든 markup을 검증하는 비용은 굉장히 비쌉니다.
+* 개발 모드에선, React가 hydration 중에 동일하지 않은 부분에 대해 경고해줍니다. 속성이 동일하지 않을 경우에 해당 속성이 올바르게 적용될 것이라고 보장할 수 없습니다. 모든 markup을 보장하지 않는 것은 성능면에서 중요하기 때문입니다. markup이 동일하지 않는 경우는 드물기 때문에 모든 markup을 검증하는 비용은 굉장히 비쌉니다.
 * 여러분은 App에서 `hydrateRoot`를 단 한 번만 호출하게 될 것입니다. 만약 프레임워크를 사용한다면, 프레임워크가 대신 호출해 줄 것입니다.
 * App을 사전에 렌더링된 HTML 없이 클라이언트에서 직접 렌더링을 한다면 `hydrateRoot()`은 지원되지 않습니다. [`createRoot()`](/reference/react-dom/client/createRoot)를 대신 사용해주세요.
 
@@ -59,19 +59,19 @@ const root = hydrateRoot(domNode, reactNode);
 
 ### `root.render(reactNode)` {/*root-render*/}
 
-hydrate된 리액트 root부터 내부 컴포넌트를 새로운 리액트 컴포넌트로 갱신하기 위해 `root.render`를 호출해주세요. 브라우저 DOM 요소들도 함께 갱신됩니다.
+hydrate된 React root부터 내부 컴포넌트를 새로운 React 컴포넌트로 갱신하기 위해 `root.render`를 호출해주세요. 브라우저 DOM 요소들도 함께 갱신됩니다.
 
 ```js
 root.render(<App />);
 ```
 
-리액트는 hydrate된 `root`부터 내부를 `<App />`으로 갱신합니다.
+React는 hydrate된 `root`부터 내부를 `<App />`으로 갱신합니다.
 
 [아래 예시를 확인해보세요.](#usage)
 
 #### Parameters {/*root-render-parameters*/}
 
-* `reactNode`: 갱신하고 싶은 "리액트 노드"입니다. 주로 `<App />`같은 JSX를 파라미터로 넘기지만, [`createElement()`](/reference/react/createElement)로 만든 리액트 엘리먼트를 넘겨도 되고 문자열이나 숫자, `null`, 혹은 `undefined`를 넘겨도 됩니다.
+* `reactNode`: 갱신하고 싶은 "React 노드"입니다. 주로 `<App />`같은 JSX를 파라미터로 넘기지만, [`createElement()`](/reference/react/createElement)로 만든 React 엘리먼트를 넘겨도 되고 문자열이나 숫자, `null`, 혹은 `undefined`를 넘겨도 됩니다.
 
 #### Returns {/*root-render-returns*/}
 
@@ -79,23 +79,23 @@ root.render(<App />);
 
 #### Caveats {/*root-render-caveats*/}
 
-* hydrate가 끝나기 전에 `root.render`를 호출하면 리액트는 서버에서 렌더링된 HTML을 모두 없애고 클라이언트에서 렌더링된 컴포넌트들로 완전히 교체합니다.
+* hydrate가 끝나기 전에 `root.render`를 호출하면 React는 서버에서 렌더링된 HTML을 모두 없애고 클라이언트에서 렌더링된 컴포넌트들로 완전히 교체합니다.
 
 ---
 
 ### `root.unmount()` {/*root-unmount*/}
 
-`root.unmount`를 호출해 리액트 root부터 그 하위에 렌더링된 트리를 삭제합니다.
+`root.unmount`를 호출해 React root부터 그 하위에 렌더링된 트리를 삭제합니다.
 
 ```js
 root.unmount();
 ```
 
-처음부터 끝까지 리액트로 만든 앱은 `root.unmount`를 호출할 경우가 거의 없습니다.
+처음부터 끝까지 React로 만든 앱은 `root.unmount`를 호출할 경우가 거의 없습니다.
 
-주로 리액트 root부터 혹은 그 상위에서부터 시작된 DOM node들을 다른 코드에 의해 DOM에서 삭제되어야 하는 경우 유용합니다. 예를 들어, jQuery 탭 패널이 활성화 되어 있지 않은 탭을 DOM에서 지운다고 가정해봅시다. 탭이 지워지면, 리액트 root와 그 내부를 포함해 그 안의 모든 것이 지워지게 되고 DOM에서 또한 지워지게 됩니다. `root.unmount`를 호출해 리액트에게 삭제된 컨텐츠들을 "그만" 다루라고 알려주어야 합니다. 그렇지 않으면 삭제되어버린 리액트 root 내부의 컴포넌트들은 삭제되지 않을 것이며, "구독"처럼 컴퓨팅 자원을 자유롭게 놓아주지 못하게 됩니다.
+주로 React root부터 혹은 그 상위에서부터 시작된 DOM node들을 다른 코드에 의해 DOM에서 삭제되어야 하는 경우 유용합니다. 예를 들어, jQuery 탭 패널이 활성화 되어 있지 않은 탭을 DOM에서 지운다고 가정해봅시다. 탭이 지워지면, React root와 그 내부를 포함해 그 안의 모든 것이 지워지게 되고 DOM에서 또한 지워지게 됩니다. `root.unmount`를 호출해 React에게 삭제된 컨텐츠들을 "그만" 다루라고 알려주어야 합니다. 그렇지 않으면 삭제되어버린 React root 내부의 컴포넌트들은 삭제되지 않을 것이며, "구독"처럼 컴퓨팅 자원을 자유롭게 놓아주지 못하게 됩니다.
 
-`root.unmount`를 호출하면 root 내부의 모든 컴포넌트를 unmount하고 root DOM node에서 리액트를 "떼어"냅니다. root 내부의 event handler와 state까지 모두 포함해 unmount 및 삭제됩니다.
+`root.unmount`를 호출하면 root 내부의 모든 컴포넌트를 unmount하고 root DOM node에서 React를 "떼어"냅니다. root 내부의 event handler와 state까지 모두 포함해 unmount 및 삭제됩니다.
 
 #### Parameters {/*root-unmount-parameters*/}
 
@@ -108,7 +108,7 @@ root.unmount();
 
 #### Caveats {/*root-unmount-caveats*/}
 
-* `root.unmount`를 호출하면 root부터 그 안의 모든 컴포넌트가 unmount되고 root DOM node에서 리액트를 떼어냅니다.
+* `root.unmount`를 호출하면 root부터 그 안의 모든 컴포넌트가 unmount되고 root DOM node에서 React를 떼어냅니다.
 
 * `root.unmount`를 한번 호출한 이후엔 `root.render`를 root에 다시 사용할 수 없습니다. unmount된 root에 다시 `root.render`를 호출하려고 한다면 "Cannot update an unmounted root" 에러를 throw하게 됩니다.
 
@@ -126,9 +126,9 @@ import { hydrateRoot } from 'react-dom/client';
 hydrateRoot(document.getElementById('root'), <App />);
 ```
 
-위 코드를 통해 서버 HTML을 <CodeStep step={1}>브라우저 DOM node</CodeStep>에서 <CodeStep step={2}>리액트 컴포넌트</CodeStep>를 이용해 hydrate 해줄 것 입니다. 주로 앱을 시작할 때 단 한 번 실행하게 될 것입니다. 프레임워크를 사용중이라면 프레임워크가 알아서 실행해 줄 것입니다.
+위 코드를 통해 서버 HTML을 <CodeStep step={1}>브라우저 DOM node</CodeStep>에서 <CodeStep step={2}>React 컴포넌트</CodeStep>를 이용해 hydrate 해줄 것 입니다. 주로 앱을 시작할 때 단 한 번 실행하게 될 것입니다. 프레임워크를 사용중이라면 프레임워크가 알아서 실행해 줄 것입니다.
 
-앱을 hydrate하기 위해서 리액트는 컴포넌트의 로직을 사전에 서버에서 만들어 진 HTML에 "붙일"것 입니다. Hydration을 통해 서버에서 만들어진 최초의 HTML 스냅샷을 브라우저에서 완전히 인터랙티브한 앱으로 바꿔주게 됩니다.
+앱을 hydrate하기 위해서 React는 컴포넌트의 로직을 사전에 서버에서 만들어 진 HTML에 "붙일"것 입니다. Hydration을 통해 서버에서 만들어진 최초의 HTML 스냅샷을 브라우저에서 완전히 인터랙티브한 앱으로 바꿔주게 됩니다.
 
 <Sandpack>
 
@@ -175,22 +175,22 @@ function Counter() {
 
 </Sandpack>
 
-`hydrateRoot`를 다시 호출하거나 다른 곳에서 더 호출할 필요는 없습니다. 이 시점부터 리액트가 애플리케이션의 DOM을 다루게 됩니다. UI를 갱신하기 위해선 [use state](/reference/react/useState)를 대신 사용해야 합니다.
+`hydrateRoot`를 다시 호출하거나 다른 곳에서 더 호출할 필요는 없습니다. 이 시점부터 React가 애플리케이션의 DOM을 다루게 됩니다. 대신 UI를 갱신하기 위해선 [state를 사용](/reference/react/useState)해야 합니다.
 
 <Pitfall>
 
-`hydrateRoot`에 전달한 리액트 트리는 서버에서 만들었던 리액트 트리 결과물과 동일해야 합니다.
+`hydrateRoot`에 전달한 React 트리는 서버에서 만들었던 React 트리 결과물과 동일해야 합니다.
 
-이는 사용자 경험을 위해서 중요합니다. 유저는 서버에서 만들어진 HTML을 JavaScript 코드가 로드될 때까지 둘러보게 됩니다. 앱의 로딩을 더 빠르게 하기 위해 서버는 일종의 신기루로서 리액트 결과물인 HTML 스냅샷을 만들어 보여줍니다. 갑자기 다른 컨텐츠를 보여주게 되면 신기루가 깨져버리게 됩니다. 이런 이유로 서버에서 렌더링한 결과물과 클라이언트에서 최초로 렌더링한 결과물이 같아야 합니다.
+이는 사용자 경험을 위해서 중요합니다. 유저는 서버에서 만들어진 HTML을 JavaScript 코드가 로드될 때까지 둘러보게 됩니다. 앱의 로딩을 더 빠르게 하기 위해 서버는 일종의 신기루로서 React 결과물인 HTML 스냅샷을 만들어 보여줍니다. 갑자기 다른 컨텐츠를 보여주게 되면 신기루가 깨져버리게 됩니다. 이런 이유로 서버에서 렌더링한 결과물과 클라이언트에서 최초로 렌더링한 결과물이 같아야 합니다.
 
 주로 아래와 같은 원인으로 hydration 에러가 일어납니다.
 
-* 리액트를 통해 만들어진 HTML의 root node안에 새 줄같은 추가적인 공백.
+* React를 통해 만들어진 HTML의 root node안에 새 줄같은 추가적인 공백.
 * `typeof window !== 'undefined'`과 같은 조건을 렌더링 로직에서 사용함.
 * [`window.matchMedia`](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia)같은 브라우저에서만 사용가능한 API를 렌더링 로직에 사용함.
 * 서버와 클라이언트에서 서로 다른 데이터를 렌더링함.
 
-리액트는 hydration 에러에서 복구됩니다, 하지만 **다른 버그들과 같이 반드시 고쳐줘야 합니다.** 가장 나은 경우는 그저 느려지기만 할 뿐이지만, 최악의 경우엔 이벤트 핸들러가 다른 element에 붙어버립니다.
+React는 hydration 에러에서 복구됩니다, 하지만 **다른 버그들과 같이 반드시 고쳐줘야 합니다.** 가장 나은 경우는 그저 느려지기만 할 뿐이지만, 최악의 경우엔 이벤트 핸들러가 다른 element에 붙어버립니다.
 
 </Pitfall>
 
@@ -198,7 +198,7 @@ function Counter() {
 
 ### document 전체를 hydrate하기 {/*hydrating-an-entire-document*/}
 
-리액트로 앱을 모두 만들었을 경우 [`<html>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html)태그를 포함해 JSX로 된 전체 document를 렌더링할 수 있습니다.
+React로 앱을 모두 만들었을 경우 [`<html>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html)태그를 포함해 JSX로 된 전체 document를 렌더링할 수 있습니다.
 
 ```js {3,13}
 function App() {
@@ -265,7 +265,7 @@ export default function App() {
 
 </Sandpack>
 
-이것은 한 단계 아래까지만 적용되며 비상 탈출구를 의도한 것입니다. 남용하지 마세요. text context가 아닌 한, 리액트는 잘못된 부분을 수정하지 않을 것이며 갱신이 일어나기 전까지는 불일치한 상태로 남아있을 것입니다.
+이것은 한 단계 아래까지만 적용되며 비상 탈출구를 의도한 것입니다. 남용하지 마세요. text context가 아닌 한, React는 잘못된 부분을 수정하지 않을 것이며 갱신이 일어나기 전까지는 불일치한 상태로 남아있을 것입니다.
 
 ---
 
@@ -323,9 +323,9 @@ export default function App() {
 
 ### hydrate된 root 컴포넌트를 업데이트하기 {/*updating-a-hydrated-root-component*/}
 
-root의 hydrating이 끝난 이후에, [`root.render`](#root-render)를 호출해 리액트 컴포넌트의 root를 업데이트 할 수 있습니다. **[`createRoot`](/reference/react-dom/client/createRoot)와는 다르게 HTML로 최초의 컨텐츠가 이미 렌더링 되어 있기 때문에 자주 사용할 필요는 없습니다.**
+root의 hydrating이 끝난 이후에, [`root.render`](#root-render)를 호출해 React 컴포넌트의 root를 업데이트 할 수 있습니다. **[`createRoot`](/reference/react-dom/client/createRoot)와는 다르게 HTML로 최초의 컨텐츠가 이미 렌더링 되어 있기 때문에 자주 사용할 필요는 없습니다.**
 
-hydration 후 어떤 시점에 `root.render`를 호출한다면, 그리고 컴포넌트의 트리 구조가 이전에 렌더링했던 구조와 일치한다면, 리액트는 [상태를 그대로 보존합니다.](/learn/preserving-and-resetting-state) input에 어떻게 타이핑하는지에 따라 문제가 발생하지 않습니다. 즉, 아래 예시에서처럼 매초 마다 상태를 업데이트하는 반복적인 `render`는 문제 없이 렌더링 된다는 것을 볼 수 있습니다:
+hydration 후 어떤 시점에 `root.render`를 호출한다면, 그리고 컴포넌트의 트리 구조가 이전에 렌더링했던 구조와 일치한다면, React는 [상태를 그대로 보존합니다.](/learn/preserving-and-resetting-state) input에 어떻게 타이핑하는지에 따라 문제가 발생하지 않습니다. 즉, 아래 예시에서처럼 매초 마다 상태를 업데이트하는 반복적인 `render`는 문제 없이 렌더링 된다는 것을 볼 수 있습니다:
 
 <Sandpack>
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

## Progress

- [x] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)


### Changelog
1. **hydrateRoot.md** 1f518a4f4a3190a4fb422b38004e0f1d1b5db6d1
    - 리액트 -> `React`로 수정 
      -  cf. [Translate Glossary - 번역하면 안되는 용어](https://github.com/reactjs/ko.react.dev/wiki/Translate-Glossary#%EB%B2%88%EC%97%AD%ED%95%98%EB%A9%B4-%EC%95%88%EB%90%98%EB%8A%94-%EC%9A%A9%EC%96%B4)
    - 오번역된 부분 수정
      - `use state` -> state를 사용
2. **react-18-upgrade-guide.md** f1867f9d729717403853699cd87f527195ca2d77
    - 번역되지 않은 부분 추가 번역
    - 번역 후 제거되지 않은 원문 제거
    - markdown 적용되도록 수정
       | as-is | to-be |
       |:---:|:---:|
       |  <img width="302" alt="as-is" src="https://github.com/reactjs/ko.react.dev/assets/69497936/51368b63-bb16-4e7a-8d38-b2368caeb50d"> | <img width="302" alt="to-be" src="https://github.com/reactjs/ko.react.dev/assets/69497936/f9c8587f-1447-48fa-b8f3-b72d75669c56">  |
3. **HomeContent.js**  b6ff70b1408221c7d23020af4923a6ae2d24e23b
    - 맞춤법 검사 및 수정
