### PR TITLE
Translate: component titles, descriptions, buttons, tags and more

### DIFF
--- a/src/components/DocsFooter.tsx
+++ b/src/components/DocsFooter.tsx
@@ -80,7 +80,7 @@ function FooterLink({
       />
       <span>
         <span className="block no-underline text-sm tracking-wide text-secondary dark:text-secondary-dark uppercase font-bold group-focus:text-link dark:group-focus:text-link-dark group-focus:text-opacity-100">
-          {type}
+          {type === 'Previous' ? '이전' : '다음'}
         </span>
         <span className="block text-lg group-hover:underline">{title}</span>
       </span>

--- a/src/components/Layout/Feedback.tsx
+++ b/src/components/Layout/Feedback.tsx
@@ -63,7 +63,9 @@ function SendFeedback({onSubmit}: {onSubmit: () => void}) {
   return (
     <div className="max-w-xs w-80 lg:w-auto py-3 shadow-lg rounded-lg m-4 bg-wash dark:bg-gray-95 px-4 flex">
       <p className="w-full font-bold text-primary dark:text-primary-dark text-lg mr-4">
-        {isSubmitted ? 'Thank you for your feedback!' : 'Is this page useful?'}
+        {isSubmitted
+          ? '피드백을 보내주셔서 감사합니다!'
+          : '이 페이지가 도움이 되었나요?'}
       </p>
       {!isSubmitted && (
         <button

--- a/src/components/MDX/Challenges/Challenge.tsx
+++ b/src/components/MDX/Challenges/Challenge.tsx
@@ -50,7 +50,7 @@ export function Challenge({
           className="text-xl text-primary dark:text-primary-dark mb-2 mt-0 font-medium"
           id={currentChallenge.id}>
           <div className="font-bold block md:inline">
-            {isRecipes ? 'Example' : 'Challenge'} {currentChallenge.order} of{' '}
+            {isRecipes ? '예제' : '챌린지'} {currentChallenge.order} of{' '}
             {totalChallenges}
             <span className="text-primary dark:text-primary-dark">: </span>
           </div>
@@ -63,14 +63,14 @@ export function Challenge({
           <div>
             <Button className="mr-2" onClick={toggleHint} active={showHint}>
               <IconHint className="mr-1.5" />{' '}
-              {showHint ? 'Hide hint' : 'Show hint'}
+              {showHint ? '힌트 숨기기' : '힌트 보기'}
             </Button>
             <Button
               className="mr-2"
               onClick={toggleSolution}
               active={showSolution}>
               <IconSolution className="mr-1.5" />{' '}
-              {showSolution ? 'Hide solution' : 'Show solution'}
+              {showSolution ? '정답 숨기기' : '정답 보기'}
             </Button>
           </div>
         ) : (
@@ -80,7 +80,7 @@ export function Challenge({
               onClick={toggleSolution}
               active={showSolution}>
               <IconSolution className="mr-1.5" />{' '}
-              {showSolution ? 'Hide solution' : 'Show solution'}
+              {showSolution ? '정답 숨기기' : '정답 보기'}
             </Button>
           )
         )}
@@ -94,7 +94,7 @@ export function Challenge({
             )}
             onClick={handleClickNextChallenge}
             active>
-            Next {isRecipes ? 'Example' : 'Challenge'}
+            다음 {isRecipes ? '예제' : '챌린지'}
             <IconArrowSmall displayDirection="right" className="block ml-1.5" />
           </Button>
         )}
@@ -104,13 +104,11 @@ export function Challenge({
       {showSolution && (
         <div className="mt-6">
           <h3 className="text-2xl font-bold text-primary dark:text-primary-dark">
-            Solution
+            해설
           </h3>
           {currentChallenge.solution}
           <div className="flex justify-between items-center mt-4">
-            <Button onClick={() => setShowSolution(false)}>
-              Close solution
-            </Button>
+            <Button onClick={() => setShowSolution(false)}>정답 닫기</Button>
             {hasNextChallenge && (
               <Button
                 className={cn(
@@ -118,7 +116,7 @@ export function Challenge({
                 )}
                 onClick={handleClickNextChallenge}
                 active>
-                Next Challenge
+                다음 챌린지
                 <IconArrowSmall
                   displayDirection="right"
                   className="block ml-1.5"

--- a/src/components/MDX/Challenges/Challenges.tsx
+++ b/src/components/MDX/Challenges/Challenges.tsx
@@ -78,7 +78,7 @@ export function Challenges({
   children,
   isRecipes,
   noTitle,
-  titleText = isRecipes ? 'Try out some examples' : 'Try out some challenges',
+  titleText = isRecipes ? '예제 살펴보기' : '챌린지 도전하기',
   titleId = isRecipes ? 'examples' : 'challenges',
 }: ChallengesProps) {
   const challenges = parseChallengeContents(children);

--- a/src/components/MDX/ExpandableCallout.tsx
+++ b/src/components/MDX/ExpandableCallout.tsx
@@ -18,7 +18,7 @@ interface ExpandableCalloutProps {
 
 const variantMap = {
   deprecated: {
-    title: 'Deprecated',
+    title: '더 이상 사용되지 않습니다',
     Icon: IconWarning,
     containerClasses: 'bg-red-5 dark:bg-red-60 dark:bg-opacity-20',
     textColor: 'text-red-50 dark:text-red-40',
@@ -26,7 +26,7 @@ const variantMap = {
       'linear-gradient(rgba(249, 247, 243, 0), rgba(249, 247, 243, 1)',
   },
   note: {
-    title: 'Note',
+    title: '중요합니다!',
     Icon: IconNote,
     containerClasses:
       'bg-green-5 dark:bg-green-60 dark:bg-opacity-20 text-primary dark:text-primary-dark text-lg',
@@ -43,7 +43,7 @@ const variantMap = {
       'linear-gradient(rgba(249, 247, 243, 0), rgba(249, 247, 243, 1)',
   },
   wip: {
-    title: 'Under Construction',
+    title: '개발중이에요',
     Icon: IconNote,
     containerClasses: 'bg-yellow-5 dark:bg-yellow-60 dark:bg-opacity-20',
     textColor: 'text-yellow-50 dark:text-yellow-40',

--- a/src/components/MDX/ExpandableExample.tsx
+++ b/src/components/MDX/ExpandableExample.tsx
@@ -101,7 +101,7 @@ function ExpandableExample({children, excerpt, type}: ExpandableExampleProps) {
           <span className="mr-1">
             <IconChevron displayDirection={isExpanded ? 'up' : 'down'} />
           </span>
-          {isExpanded ? 'Hide Details' : 'Show Details'}
+          {isExpanded ? '숨기기' : '자세히 보기'}
         </Button>
       </summary>
       <div

--- a/src/components/MDX/MDXComponents.tsx
+++ b/src/components/MDX/MDXComponents.tsx
@@ -113,7 +113,7 @@ function LearnMore({
       <section className="p-8 mt-16 mb-16 flex flex-row shadow-inner-border dark:shadow-inner-border-dark justify-between items-center bg-card dark:bg-card-dark rounded-2xl">
         <div className="flex-col">
           <h2 className="text-primary font-display dark:text-primary-dark font-bold text-2xl leading-tight">
-            Ready to learn this topic?
+            이 주제를 배울 준비가 되셨나요?
           </h2>
           {children}
           {path ? (
@@ -122,7 +122,7 @@ function LearnMore({
               label="Read More"
               href={path}
               type="primary">
-              Read More
+              더 보기
               <IconNavArrow displayDirection="right" className="inline ml-1" />
             </ButtonLink>
           ) : null}
@@ -173,7 +173,7 @@ function YouWillLearn({
   children: any;
   isChapter?: boolean;
 }) {
-  let title = isChapter ? 'In this chapter' : 'You will learn';
+  let title = isChapter ? '이 장에서는' : '학습 내용';
   return <SimpleCallout title={title}>{children}</SimpleCallout>;
 }
 

--- a/src/components/MDX/Recap.tsx
+++ b/src/components/MDX/Recap.tsx
@@ -13,7 +13,7 @@ function Recap({children}: RecapProps) {
   return (
     <section>
       <H2 isPageAnchor id="recap">
-        Recap
+        요약
       </H2>
       {children}
     </section>

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -7,23 +7,23 @@ import type {RouteTag} from './Layout/getRouteMeta';
 
 const variantMap = {
   foundation: {
-    name: 'Foundation',
+    name: '기초',
     classes: 'bg-yellow-50 text-white',
   },
   intermediate: {
-    name: 'Intermediate',
+    name: '중급',
     classes: 'bg-purple-40 text-white',
   },
   advanced: {
-    name: 'Advanced',
+    name: '심화',
     classes: 'bg-green-40 text-white',
   },
   experimental: {
-    name: 'Experimental',
+    name: '실험적',
     classes: 'bg-ui-orange text-white',
   },
   deprecated: {
-    name: 'Deprecated',
+    name: '더 이상 사용되지 않음',
     classes: 'bg-red-40 text-white',
   },
 };


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

## Progress

- [x] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)

## ChangeLog

사이트 내 다양한 컴포넌트에서 사용되는 타이틀, 설명, 버튼명, 태그 등의 번역을 추가하였습니다.

|No.| Desc | Path (src/components) | Screenshot |
|:---|:---|:---|:---|
| 1 | 이전,다음 버튼 | DocsFooter.tsx | <img width="907" alt="이전,다음" src="https://github.com/reactjs/ko.react.dev/assets/69497936/0c63d7a0-a654-4af4-9183-a0b701a37d0a"> |
| 2 | 피드백 | Layout/Feedback.tsx | <img width="791" alt="피드백" src="https://github.com/reactjs/ko.react.dev/assets/69497936/d282ea29-248c-41f9-bf43-84066acef926"> |
| 3 | 챌린지 | MDX/Challenges/Challenge.tsx<br/>MDX/Challenges/Challenges.tsx  | <img width="982" alt="챌린지1" src="https://github.com/reactjs/ko.react.dev/assets/69497936/be2a2195-a334-4e69-80a5-8604d337b428"><br/><img width="987" alt="챌린지2" src="https://github.com/reactjs/ko.react.dev/assets/69497936/ab0f26c4-61b1-4fb0-8ae0-fd9c43d8fc01"> |
| 4 | 예제 | MDX/Challenges/Challenge.tsx  | <img width="978" alt="예제" src="https://github.com/reactjs/ko.react.dev/assets/69497936/1d1bec3e-9800-4acc-b3dd-d85a8f380b29"> |
| 5 | callout 제목<br/><br/> cf. #632 | MDX/ExpandableCallout.tsx | <img width="1001" alt="주의하세요2" src="https://github.com/reactjs/ko.react.dev/assets/69497936/1d36accc-7dbe-403e-81fa-09690949cdf7"><img width="1001" alt="중요합니다" src="https://github.com/reactjs/ko.react.dev/assets/69497936/792c4f38-6c24-46ac-b6e2-5643e49019a0">|
| 6 | 자세히 보기 버튼 | MDX/ExpandableExample.tsx | <img width="936" alt="자세히보기" src="https://github.com/reactjs/ko.react.dev/assets/69497936/0ee30264-cc08-4cc0-9b2b-96794827d3bf"> |
| 7 | 더 배우기 | MDX/MDXComponents.tsx | <img width="1001" alt="더배우기" src="https://github.com/reactjs/ko.react.dev/assets/69497936/b73e7e87-8f54-4f94-b52c-e64646ce19f0"> |
| 8 | 학습 내용 | MDX/MDXComponents.tsx |<img width="1001" alt="학습내용" src="https://github.com/reactjs/ko.react.dev/assets/69497936/eabddc67-33e2-49c8-ad50-8c21e53a3a25"><img width="1001" alt="이장에서는" src="https://github.com/reactjs/ko.react.dev/assets/69497936/2b04b631-3708-4b4e-82db-900174d75388"> |
| 9 | 요약 | MDX/Recap.tsx | <img width="1204" alt="요약" src="https://github.com/reactjs/ko.react.dev/assets/69497936/eeff2501-9111-4cec-83f1-9443579b15ab"> |
| 10 | 태그 | Tag.tsx |<img width="180" alt="tag1" src="https://github.com/reactjs/ko.react.dev/assets/69497936/5bcf3031-1309-4f25-bbd0-9ee0a4810467"><img width="200" alt="tag2" src="https://github.com/reactjs/ko.react.dev/assets/69497936/3200138b-ce28-470d-8b99-b0dfb4a7884b"> |
















