### PR TITLE
Translate: DocsFooter/FooterLink type

### DIFF
--- a/src/components/DocsFooter.tsx
+++ b/src/components/DocsFooter.tsx
@@ -65,6 +65,10 @@ function FooterLink({
   title: string;
   type: 'Previous' | 'Next';
 }) {
+  const toKorean = {
+    Previous: '이전',
+    Next: '다음',
+  };
   return (
     <NextLink
       href={href}
@@ -80,7 +84,7 @@ function FooterLink({
       />
       <span>
         <span className="block no-underline text-sm tracking-wide text-secondary dark:text-secondary-dark uppercase font-bold group-focus:text-link dark:group-focus:text-link-dark group-focus:text-opacity-100">
-          {type}
+          {toKorean[type]}
         </span>
         <span className="block text-lg group-hover:underline">{title}</span>
       </span>


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

FooterLink의 "Next", "Previous"로 표기되어 있는 부분을 한글 "다음", "이전"으로 번역하였습니다.

## AS-IS

<img width="645" alt="Screenshot 2023-07-31 at 14 25 38" src="https://github.com/reactjs/ko.react.dev/assets/48273875/62723faf-9715-4874-8b7a-2d0415204e22">

## TO-BE

<img width="651" alt="Screenshot 2023-07-31 at 14 25 11" src="https://github.com/reactjs/ko.react.dev/assets/48273875/95acd1e2-ce65-46bc-b801-67216ed7f03e">


## Progress

- [x] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
