### PR TITLE
Translate: `<SandPack>`, `<TerminalBlock>`, TableOfContent

### DIFF
--- a/src/components/Layout/Toc.tsx
+++ b/src/components/Layout/Toc.tsx
@@ -16,7 +16,7 @@ export function Toc({headings}: {headings: Toc}) {
     <nav role="navigation" className="pt-20 sticky top-0 end-0">
       {headings.length > 0 && (
         <h2 className="mb-3 lg:mb-3 uppercase tracking-wide font-bold text-sm text-secondary dark:text-secondary-dark px-4 w-full">
-          On this page
+          이 페이지의 내용
         </h2>
       )}
       <div

--- a/src/components/MDX/Sandpack/CustomPreset.tsx
+++ b/src/components/MDX/Sandpack/CustomPreset.tsx
@@ -102,7 +102,7 @@ const SandboxShell = memo(function SandboxShell({
                   className="inline me-1.5 text-xl"
                   displayDirection={isExpanded ? 'up' : 'down'}
                 />
-                {isExpanded ? 'Show less' : 'Show more'}
+                {isExpanded ? '간략히 보기' : '자세히 보기'}
               </span>
             </button>
           )}

--- a/src/components/MDX/Sandpack/DownloadButton.tsx
+++ b/src/components/MDX/Sandpack/DownloadButton.tsx
@@ -103,7 +103,7 @@ ${css}
       onClick={downloadHTML}
       title="Download Sandbox"
       type="button">
-      <IconDownload className="inline me-1" /> Download
+      <IconDownload className="inline me-1" /> 다운로드
     </button>
   );
 }

--- a/src/components/MDX/Sandpack/NavigationBar.tsx
+++ b/src/components/MDX/Sandpack/NavigationBar.tsx
@@ -105,7 +105,7 @@ export function NavigationBar({providedFiles}: {providedFiles: Array<string>}) {
      */
     if (
       sandpack.editorState === 'dirty' &&
-      confirm('Reset all your edits too?')
+      confirm('모든 수정 사항이 초기화됩니다. 계속하시겠습니까?')
     ) {
       sandpack.resetAllFiles();
     }

--- a/src/components/MDX/Sandpack/OpenInCodeSandboxButton.tsx
+++ b/src/components/MDX/Sandpack/OpenInCodeSandboxButton.tsx
@@ -15,7 +15,7 @@ export const OpenInCodeSandboxButton = () => {
         width="1em"
         height="1em"
       />
-      <span className="hidden md:block">Fork</span>
+      <span className="hidden md:block">포크</span>
     </UnstyledOpenInCodeSandboxButton>
   );
 };

--- a/src/components/MDX/Sandpack/ResetButton.tsx
+++ b/src/components/MDX/Sandpack/ResetButton.tsx
@@ -15,7 +15,7 @@ export function ResetButton({onReset}: ResetButtonProps) {
       onClick={onReset}
       title="Reset Sandbox"
       type="button">
-      <IconRestart className="inline mx-1 relative" /> Reset
+      <IconRestart className="inline mx-1 relative" /> 초기화
     </button>
   );
 }

--- a/src/components/MDX/TerminalBlock.tsx
+++ b/src/components/MDX/TerminalBlock.tsx
@@ -55,7 +55,7 @@ function TerminalBlock({level = 'info', children}: TerminalBlockProps) {
       <div className="bg-gray-90 dark:bg-gray-60 w-full rounded-t-lg">
         <div className="text-primary-dark dark:text-primary-dark flex text-sm px-4 py-0.5 relative justify-between">
           <div>
-            <IconTerminal className="inline-flex me-2 self-center" /> Terminal
+            <IconTerminal className="inline-flex me-2 self-center" /> 터미널
           </div>
           <div>
             <button
@@ -65,7 +65,7 @@ function TerminalBlock({level = 'info', children}: TerminalBlockProps) {
                 setCopied(true);
               }}>
               <IconCopy className="inline-flex me-2 self-center" />{' '}
-              {copied ? 'Copied' : 'Copy'}
+              {copied ? '복사됨' : '복사'}
             </button>
           </div>
         </div>

--- a/src/utils/prepareMDX.js
+++ b/src/utils/prepareMDX.js
@@ -65,7 +65,7 @@ function getTableOfContents(children, depth) {
   if (anchors.length > 0) {
     anchors.unshift({
       url: '#',
-      text: 'Overview',
+      text: '훑어보기',
       depth: 2,
     });
   }


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

<img width="1732" alt="Screenshot 2023-11-16 at 00 53 42" src="https://github.com/reactjs/ko.react.dev/assets/48273875/51264a53-35cf-4266-8ab7-03842e6917eb">

`<SandPack>`, `<TerminalBlock>`, TableOfContent 중 아직 번역되지 않은 부분을 번역하였습니다.

번역에 대해 의견 주시면 반영하도록 하겠습니다!

## Progress

- [x] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
