### PR TITLE
fix : 오타 및 마크다운 문서 내 경로 수정

### DIFF
--- a/src/content/learn/referencing-values-with-refs.md
+++ b/src/content/learn/referencing-values-with-refs.md
@@ -81,7 +81,7 @@ const [startTime, setStartTime] = useState(null);
 const [now, setNow] = useState(null);
 ```
 
-사용자가 "시작"을 누르면 [`setInterval`](https://developer.mozilla.org/docs/Web/API/setInterval)을 사용하여 100밀리초마다 시간을 업데이트합니다.
+사용자가 "시작"을 누르면 [`setInterval`](https://developer.mozilla.org/docs/Web/API/setInterval)을 사용하여 10밀리초마다 시간을 업데이트합니다.
 
 <Sandpack>
 

--- a/src/content/reference/react/Fragment.md
+++ b/src/content/reference/react/Fragment.md
@@ -111,7 +111,7 @@ function Post() {
 }
 ```
 
-일반적으로 [`Fragment`에 `key`를 넘겨야 하는 경우]((#rendering-a-list-of-fragments))가 아니라면 이 기능은 필요하지 않습니다.
+일반적으로 [`Fragment`에 `key`를 넘겨야 하는 경우](#rendering-a-list-of-fragments)가 아니라면 이 기능은 필요하지 않습니다.
 
 </DeepDive>
 

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -10,7 +10,10 @@ const {Intro, MaxWidth, p: P, a: A} = MDXComponents;
 
 export default function NotFound() {
   return (
-    <Page toc={[]} meta={{title: '페이지를 찾을 수 없습니다'}} routeTree={sidebarLearn}>
+    <Page
+      toc={[]}
+      meta={{title: '페이지를 찾을 수 없습니다'}}
+      routeTree={sidebarLearn}>
       <MaxWidth>
         <Intro>
           <P>요청하신 페이지가 존재하지 않습니다.</P>
@@ -18,10 +21,8 @@ export default function NotFound() {
             저희 잘못으로 인한 오류라면{', '}
             수정할 수 있도록{' '}
             <A href="https://github.com/reactjs/react.dev/issues/new">
-            저희에게 알려주세요
+              저희에게 알려주세요.
             </A>
-            {'. '}
-            
           </P>
         </Intro>
       </MaxWidth>


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

공식 문서 내 오타 및 잘못된 하이퍼링크 경로를 수정합니다.
- `Fragment.md` : 문서 내 경로에 불필요한 `()` 제거
- `referencing-values-with-refs` : 100밀리초 -> 10밀리초 ([원문 링크](https://github.com/reactjs/react.dev/blob/main/src/content/learn/referencing-values-with-refs.md#example-building-a-stopwatch-example-building-a-stopwatch))

## Progress

- [x] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [x] 리뷰 반영 (Resolve reviews)
