### PR TITLE
fix: missing part of reducer

### DIFF
--- a/src/content/learn/reacting-to-input-with-state.md
+++ b/src/content/learn/reacting-to-input-with-state.md
@@ -240,7 +240,7 @@ export default function Form({
 
 <DeepDive>
 
-#### Displaying many visual states at once {/*displaying-many-visual-states-at-once*/}
+#### 많은 시각적 state를 한 번에 보여주기 {/*displaying-many-visual-states-at-once*/}
 
 컴포넌트가 많은 시각적 state를 가지고 있다면 한 페이지에서 모두 보여주는 것도 편하게 할 수 있습니다.
 
@@ -391,7 +391,7 @@ const [status, setStatus] = useState('typing'); // 'typing', 'submitting', or 's
 
 <DeepDive>
 
-#### Eliminating "impossible" states with a reducer {/*eliminating-impossible-states-with-a-reducer*/}
+#### Reducer를 사용하여 "불가능한" state 제거 {/*eliminating-impossible-states-with-a-reducer*/}
 
 여기 폼의 state를 나타내는데 충분한 세 가지 변수가 있습니다. 하지만 세 변수는 여전히 말이 안 되는 일부 중간 state를 가지고 있습니다. 예를 들면 `error`가 null이 아닌데 `status`가 `success`인 것은 말이 되지 않습니다. state를 조금 더 정확하게 모델링하기 위해서는 [리듀서로 분리](/learn/extracting-state-logic-into-a-reducer)하는 방법도 있습니다. 리듀서를 사용하면 여러 state 변수를 하나의 객체로 통합하고 관련된 모든 로직도 합칠 수 있습니다!
 

--- a/src/content/learn/render-and-commit.md
+++ b/src/content/learn/render-and-commit.md
@@ -140,7 +140,7 @@ img { margin: 0 10px 10px 0; }
 
 <DeepDive>
 
-#### Optimizing performance {/*optimizing-performance*/}
+#### 성능 최적화 {/*optimizing-performance*/}
 
 업데이트된 컴포넌트 내에 중첩된 모든 컴포넌트를 렌더링하는 기본 동작은 업데이트된 컴포넌트가 트리에서 매우 높은 곳에 있는 경우 성능 최적화되지 않습니다. 성능 문제가 발생하는 경우 [성능](https://ko.legacy.reactjs.org/docs/optimizing-performance.html) 섹션에 설명된 몇 가지 옵트인 방식으로 문제를 해결 할 수 있습니다. **성급하게 최적화하지 마세요!**
 

--- a/src/content/learn/scaling-up-with-reducer-and-context.md
+++ b/src/content/learn/scaling-up-with-reducer-and-context.md
@@ -207,9 +207,9 @@ ul, li { margin: 0; padding: 0; }
 
 </Sandpack>
 
-A reducer helps keep the event handlers short and concise. However, as your app grows, you might run into another difficulty. **Currently, the `tasks` state and the `dispatch` function are only available in the top-level `TaskApp` component.** To let other components read the list of tasks or change it, you have to explicitly [pass down](/learn/passing-props-to-a-component) the current state and the event handlers that change it as props.
+Reducer는 이벤트 핸들러를 짧고 간결하게 유지하는 데 도움이 됩니다. 그러나 앱이 커지면 다른 어려움에 부딪힐지도 모릅니다. **현재 `tasks` state 및 `dispatch` 함수는 최상위 `TaskApp` 컴포넌트에서만 사용할 수 있습니다.** 다른 컴포넌트가 작업 목록을 읽거나 변경하려면 현재 state와 해당 state를 변경하는 이벤트 핸들러를 명시적으로 [props로 전달](/learn/passing-props-to-a-component)해야 합니다.
 
-For example, `TaskApp` passes a list of tasks and the event handlers to `TaskList`:
+예를 들어, `TaskApp`은 tasks 리스트와 이벤트 핸들러를 `TaskList`에 전달합니다.
 
 ```js
 <TaskList
@@ -231,7 +231,7 @@ For example, `TaskApp` passes a list of tasks and the event handlers to `TaskLis
 
 지금처럼 간단한 예시에서는 잘 동작하지만, 수십 수백개의 컴포넌트를 거쳐 state나 함수를 전달하기는 쉽지 않습니다.
 
-This is why, as an alternative to passing them through props, you might want to put both the `tasks` state and the `dispatch` function [into context](/learn/passing-data-deeply-with-context). **This way, any component below `TaskApp` in the tree can read the tasks and dispatch actions without the repetitive "prop drilling".**
+이것이 props를 통한 전달 대신 `tasks` state와 `dispatch` 함수를 모두 [context에 넣고](/learn/passing-data-deeply-with-context) 싶은 이유입니다. **이렇게 하면 트리에서 `TaskApp` 아래에 있는 모든 컴포넌트가 "prop drilling"이라는 반복적인 작업 없이 tasks와 dispatch actions를 읽을 수 있습니다.**
 
 Reducer와 context를 결합하는 방법은 아래와 같습니다.
 
@@ -448,11 +448,11 @@ ul, li { margin: 0; padding: 0; }
 
 </Sandpack>
 
-Here, you're passing `null` as the default value to both contexts. The actual values will be provided by the `TaskApp` component.
+여기서는 두 컨텍스트에 모두 기본값으로 `null`을 전달하고 있습니다. 실제 값은 `TaskApp` 컴포넌트에서 제공될 것입니다.
 
 ### 2단계: State과 dispatch 함수를 context에 넣기 {/*step-2-put-state-and-dispatch-into-context*/}
 
-Now you can import both contexts in your `TaskApp` component. Take the `tasks` and `dispatch` returned by `useReducer()` and [provide them](/learn/passing-data-deeply-with-context#step-3-provide-the-context) to the entire tree below:
+이제 `TaskApp` 컴포넌트에서 두 컨텍스트를 모두 가져올 수 있습니다. `useReducer()`에서 반환된 `tasks` 및 `dispatch`를 가져와 아래 트리 전체에 [제공](/learn/passing-data-deeply-with-context#step-3-provide-the-context)하세요.
 
 ```js {4,7-8}
 import { TasksContext, TasksDispatchContext } from './TasksContext.js';
@@ -685,7 +685,7 @@ ul, li { margin: 0; padding: 0; }
 </TasksContext.Provider>
 ```
 
-대신 필요한 컴포넌트에서는 `TaskContext`에서 task 리스트를 읽을 수 있습니다.
+대신 필요한 컴포넌트에서는 `TaskContext`에서 tasks 리스트를 읽을 수 있습니다.
 
 ```js {2}
 export default function TaskList() {
@@ -693,7 +693,7 @@ export default function TaskList() {
   // ...
 ```
 
-task 리스트를 업데이트하기 위해서 컴포넌트에서 context의 `dispatch` 함수를 읽고 호출할 수 있습니다.
+tasks 리스트를 업데이트하기 위해서 컴포넌트에서 context의 `dispatch` 함수를 읽고 호출할 수 있습니다.
 
 ```js {3,9-13}
 export default function AddTask({ onAddTask }) {
@@ -713,7 +713,7 @@ export default function AddTask({ onAddTask }) {
     // ...
 ```
 
-**The `TaskApp` component does not pass any event handlers down, and the `TaskList` does not pass any event handlers to the `Task` component either.** Each component reads the context that it needs:
+**`TaskApp` 컴포넌트는 어떤 이벤트 핸들러도 아래로 전달하지 않으며, `TaskList`도 `Task` 컴포넌트로 이벤트 핸들러를 전달하지 않습니다.** 각 컴포넌트는 필요한 컨텍스트를 읽습니다.
 
 <Sandpack>
 
@@ -897,7 +897,7 @@ ul, li { margin: 0; padding: 0; }
 
 </Sandpack>
 
-**The state still "lives" in the top-level `TaskApp` component, managed with `useReducer`.** But its `tasks` and `dispatch` are now available to every component below in the tree by importing and using these contexts.
+**State는 여전히 최상위 `TaskApp` 컴포넌트에서 `useReducer`로 관리되고 있습니다.** 그러나 이제 context를 가져와 트리 아래의 모든 컴포넌트에서 해당 `tasks` 및 `dispatch`를 사용할 수 있습니다.
 
 ## 하나의 파일로 합치기 {/*moving-all-wiring-into-a-single-file*/}
 
@@ -930,7 +930,7 @@ export function TasksProvider({ children }) {
 }
 ```
 
-**This removes all the complexity and wiring from your `TaskApp` component:**
+**이렇게 하면 `TaskApp` 컴포넌트의 복잡성과 연결이 모두 제거됩니다.**
 
 <Sandpack>
 

--- a/src/content/learn/scaling-up-with-reducer-and-context.md
+++ b/src/content/learn/scaling-up-with-reducer-and-context.md
@@ -448,11 +448,11 @@ ul, li { margin: 0; padding: 0; }
 
 </Sandpack>
 
-여기서는 두 컨텍스트에 모두 기본값으로 `null`을 전달하고 있습니다. 실제 값은 `TaskApp` 컴포넌트에서 제공될 것입니다.
+여기서는 두 context에 모두 기본값으로 `null`을 전달하고 있습니다. 실제 값은 `TaskApp` 컴포넌트에서 제공될 것입니다.
 
 ### 2단계: State과 dispatch 함수를 context에 넣기 {/*step-2-put-state-and-dispatch-into-context*/}
 
-이제 `TaskApp` 컴포넌트에서 두 컨텍스트를 모두 가져올 수 있습니다. `useReducer()`에서 반환된 `tasks` 및 `dispatch`를 가져와 아래 트리 전체에 [제공](/learn/passing-data-deeply-with-context#step-3-provide-the-context)하세요.
+이제 `TaskApp` 컴포넌트에서 두 context를 모두 가져올 수 있습니다. `useReducer()`에서 반환된 `tasks` 및 `dispatch`를 가져와 아래 트리 전체에 [제공](/learn/passing-data-deeply-with-context#step-3-provide-the-context)하세요.
 
 ```js {4,7-8}
 import { TasksContext, TasksDispatchContext } from './TasksContext.js';
@@ -713,7 +713,7 @@ export default function AddTask({ onAddTask }) {
     // ...
 ```
 
-**`TaskApp` 컴포넌트는 어떤 이벤트 핸들러도 아래로 전달하지 않으며, `TaskList`도 `Task` 컴포넌트로 이벤트 핸들러를 전달하지 않습니다.** 각 컴포넌트는 필요한 컨텍스트를 읽습니다.
+**`TaskApp` 컴포넌트는 어떤 이벤트 핸들러도 아래로 전달하지 않으며, `TaskList`도 `Task` 컴포넌트로 이벤트 핸들러를 전달하지 않습니다.** 각 컴포넌트는 필요한 context를 읽습니다.
 
 <Sandpack>
 


### PR DESCRIPTION
### 1. Deep Dive Title 번역 누락
- [렌더링 그리고 커밋](https://ko.react.dev/learn/render-and-commit)
<img width="240" alt="Screenshot 2024-02-23 at 6 29 58 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/d35c3282-b4d8-47d2-aeba-0c4581e0404f"><img width="210" alt="Screenshot 2024-02-23 at 6 29 28 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/44c6363f-cff4-4272-a1ed-ac7d009dce15">
- [State를 사용해 Input 다루기](https://ko.react.dev/learn/reacting-to-input-with-state)
<img width="340" alt="Screenshot 2024-02-23 at 6 32 50 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/a5b875b5-d307-49a2-aa51-8892caec9160"><img width="300" alt="Screenshot 2024-02-23 at 6 33 11 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/45290b36-9f67-4e35-8835-9b629406df1d">
<img width="340" alt="Screenshot 2024-02-23 at 6 34 03 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/04b45d74-7854-4201-83b1-70ebb7816f73"><img width="302" alt="Screenshot 2024-02-23 at 6 34 15 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/27102df8-f9b7-44d1-88fb-8a3b3d34b4a4">

### 2. [Reducer와 Context로 앱 확장하기](https://ko.react.dev/learn/scaling-up-with-reducer-and-context) 페이지 번역 누락
- [tasks 리스트 / task 리스트] 혼용되어 있던 표현을 **tasks 리스트** 로 통일
   예제에서 tasks라는 변수에 리스트를 담고 사용되고 있는데요, 변수명 그대로인 복수형이 자연스럽지 않을까 생각했습니다.
---

- 누락된 문단들을 번역 
<img width="700" alt="Screenshot 2024-02-23 at 6 40 12 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/82baa356-a71d-4888-b466-b72ec64ecfa6">
<img width="700" alt="Screenshot 2024-02-23 at 6 40 48 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/07abee9b-ee9f-4a83-a41d-6e6b20903b76">

---
<img width="700" alt="Screenshot 2024-02-23 at 6 42 57 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/63e34714-b90e-485d-b8d3-656a0fa43fd1">
<img width="700" alt="Screenshot 2024-02-23 at 6 43 15 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/5d35904f-9950-41c4-80e4-d46d9540f4b2">

---
<img width="700" alt="Screenshot 2024-02-23 at 6 44 29 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/d5ed53a1-cdad-4b00-90a6-da13ac3e7c6a">
<img width="700" alt="Screenshot 2024-02-23 at 6 53 05 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/a008307f-0a56-4898-9836-edd2f68adebc">

---
<img width="700" alt="Screenshot 2024-02-23 at 6 45 09 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/803222be-e5fc-4081-98c0-63fd597f13a6">
<img width="700" alt="Screenshot 2024-02-23 at 6 53 57 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/c299a843-5e9c-4ede-aae1-b024440cdc95">

---
<img width="700" alt="Screenshot 2024-02-23 at 6 45 37 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/f26de65f-2b5f-41a8-924f-fe13ee63fbd9">
<img width="700" alt="Screenshot 2024-02-23 at 6 45 48 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/6a3a56b8-e448-4d5c-9236-2d3dd36cea86">

---
<img width="635" alt="Screenshot 2024-02-23 at 6 46 02 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/41633dd6-fdf8-4106-9d93-163b3492a36f">
<img width="525" alt="Screenshot 2024-02-23 at 6 46 13 PM" src="https://github.com/reactjs/ko.react.dev/assets/52682692/73d694d8-46ae-49c4-8548-49f00eabf3f5">



## Progress

- [x] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
