### PR TITLE
fix: Add missing translations

### DIFF
--- a/src/content/reference/react-dom/components/select.md
+++ b/src/content/reference/react-dom/components/select.md
@@ -44,31 +44,30 @@ select box를 표시하려면 [`<select>` 내장 컴포넌트](https://developer
 
 `value`를 전달할 때, 전달된 `value`를 업데이트하는 `onChange` 핸들러를 전달해야 합니다.
 
-만약 `<select>`가 제어되지 않는다면, `defaultValue` prop을 전달합니다.
+`<select>`가 제어되지 않는다면, `defaultValue` prop을 전달합니다.
 
 * `defaultValue` : String 타입 (또는 [`multiple={true}`](#enabling-multiple-selection)에서 사용하는 String 배열)이며 [초기 선택 옵션을](#providing-an-initially-selected-option) 지정합니다.
 
 `<select>` props는 제어되지 않는 상태와 제어되는 상태 모두에 적용됩니다.
-
-* [`autoComplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#autocomplete): A string. Specifies one of the possible [autocomplete behaviors.](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values)
-* [`autoFocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#autofocus): A boolean. If `true`, React will focus the element on mount.
-* `children`: `<select>` accepts [`<option>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option), [`<optgroup>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup), and [`<datalist>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist) components as children. You can also pass your own components as long as they eventually render one of the allowed components. If you pass your own components that eventually render `<option>` tags, each `<option>` you render must have a `value`.
-* [`disabled`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#disabled): A boolean. If `true`, the select box will not be interactive and will appear dimmed.
-* [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#form): A string. Specifies the `id` of the `<form>` this select box belongs to. If omitted, it's the closest parent form.
-* [`multiple`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#multiple): A boolean. If `true`, the browser allows [multiple selection.](#enabling-multiple-selection)
-* [`name`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#name): A string. Specifies the name for this select box that's [submitted with the form.](#reading-the-select-box-value-when-submitting-a-form)
-* `onChange`: An [`Event` handler](/reference/react-dom/components/common#event-handler) function. Required for [controlled select boxes.](#controlling-a-select-box-with-a-state-variable) Fires immediately when the user picks a different option. Behaves like the browser [`input` event.](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)
-* `onChangeCapture`: A version of `onChange` that fires in the [capture phase.](/learn/responding-to-events#capture-phase-events)
-* [`onInput`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event): An [`Event` handler](/reference/react-dom/components/common#event-handler) function. Fires immediately when the value is changed by the user. For historical reasons, in React it is idiomatic to use `onChange` instead which works similarly.
-* `onInputCapture`: A version of `onInput` that fires in the [capture phase.](/learn/responding-to-events#capture-phase-events)
-* [`onInvalid`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event): An [`Event` handler](/reference/react-dom/components/common#event-handler) function. Fires if an input fails validation on form submit. Unlike the built-in `invalid` event, the React `onInvalid` event bubbles.
-* `onInvalidCapture`: A version of `onInvalid` that fires in the [capture phase.](/learn/responding-to-events#capture-phase-events)
-* [`required`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#required): A boolean. If `true`, the value must be provided for the form to submit.
-* [`size`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#size): A number. For `multiple={true}` selects, specifies the preferred number of initially visible items.
+* [`autoComplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#autocomplete): 문자열 타입. 가능한 [자동완성 동작](https://developer.mozilla.org/ko/docs/Web/HTML/Attributes/autocomplete#%EA%B0%92) 중 하나를 지정합니다.
+* [`autoFocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#autofocus): 불리언 타입. `true`이면 React가 마운트 시 해당 엘리먼트에 포커싱합니다.
+* `children`: `<select>`는 자식으로 [`<option>`](https://developer.mozilla.org/ko/docs/Web/HTML/Element/option), [`<optgroup>`](https://developer.mozilla.org/ko/docs/Web/HTML/Element/optgroup), [`<datalist>`](https://developer.mozilla.org/ko/docs/Web/HTML/Element/datalist) 컴포넌트를 받습니다. 또한 허용되는 컴포넌트 중 하나를 렌더링하기만 한다면 사용자 정의 컴포넌트를 전달할 수도 있습니다. 최종적으로 `<option>` 태그를 렌더링하는 사용자 정의 컴포넌트를 전달한다면, 렌더링되는 모든 `<option>` 은 `value`를 가져야 합니다.
+* [`disabled`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#disabled): 불리언 타입. `true`일 경우 select box는 상호작용할 수 없게 되고 흐리게 표시됩니다.
+* [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#form): 문자열 타입. 이 select box가 속하는 `<form>`의  `id`를 지정합니다. 생략되면 가장 가까운 부모 폼으로 지정됩니다.
+* [`multiple`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#multiple): 불리언 타입. `true`이면 브라우저가 [다중 선택](#enabling-multiple-selection)을 허용합니다.
+* [`name`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#name): 문자열 타입. [양식과 함께 제출되는](#reading-the-select-box-value-when-submitting-a-form) select box의 이름을 지정합니다.
+* `onChange`: [`Event` 핸들러](/reference/react-dom/components/common#event-handler) 함수. [제어되는 select box](#controlling-a-select-box-with-a-state-variable)에 필수적입니다. 사용자가 다른 옵션을 선택하는 즉시 실행됩니다. 브라우저의 [`input` 이벤트](https://developer.mozilla.org/ko/docs/Web/API/HTMLElement/input_event)처럼 동작합니다.
+* `onChangeCapture`: [캡처 단계](/learn/responding-to-events#capture-phase-events)에서 실행되는 버전의 `onChange`.
+* [`onInput`](https://developer.mozilla.org/ko/docs/Web/API/HTMLElement/input_event): [`Event` 핸들러](/reference/react-dom/components/common#event-handler) 함수. 사용자에 의해 값이 변경되는 즉시 실행됩니다. 역사적인 이유로 React에서는 유사하게 동작하는 `onChange`를 대신 사용하는 것이 관용적입니다.
+* `onInputCapture`: [캡처 단계](/learn/responding-to-events#capture-phase-events)에서 실행되는 버전의 `inputCapture`.
+* [`onInvalid`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event): [`Event` 핸들러](/reference/react-dom/components/common#event-handler) 함수. 양식 제출 시 입력 유효성 검사에 실패하면 실행됩니다. 내장 `invalid` 이벤트와 다르게, React의 `onInvalid` 이벤트는 버블링됩니다.
+* `onInvalidCapture`: [캡처 단계](/learn/responding-to-events#capture-phase-events)에서 실행되는 버전의 `invalidCapture`.
+* [`required`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#required): 불리언 타입. `true`일 경우 양식을 제출할 때 값이 반드시 제공되어야 합니다.
+* [`size`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#size): 숫자 타입. `multiple={true}`인 select에 대해, 초기에 표시되는 기본 항목의 수를 지정합니다.
 
 #### 주의 사항 {/*caveats*/}
 
-- HTML과는 달리, `selected` 속성을 `<option>`에 전달하는 것은 지원하지 않습니다. 대신, [제어되지 않는 select box](#controlling-a-select-box-with-a-state-variable)인 경우 [`<select defaultValue>`](#providing-an-initially-selected-option)를 사용하고, [제어되어야 하는 select box](#controlling-a-select-box-with-a-state-variable)인 경우 [`<select value>`](#controlling-a-select-box-with-a-state-variable)를 사용해야 합니다.
+- HTML과는 달리, `selected` 어트리뷰트를 `<option>`에 전달하는 것은 지원하지 않습니다. 대신, [제어되지 않는 select box](#controlling-a-select-box-with-a-state-variable)인 경우 [`<select defaultValue>`](#providing-an-initially-selected-option)를 사용하고, [제어되어야 하는 select box](#controlling-a-select-box-with-a-state-variable)인 경우 [`<select value>`](#controlling-a-select-box-with-a-state-variable)를 사용해야 합니다.
 - `<select>`에 `value` prop이 전달된다면, [제어되는 것으로 간주합니다.](#controlling-a-select-box-with-a-state-variable)
 - select box는 제어 상태와 비제어 상태를 동시에 행할 수 없습니다. 둘 중 하나의 상태만 가질 수 있습니다.
 - select box는 생명 주기 동안 처음 설정한 제어 상태를 변경할 수 없습니다.
@@ -109,7 +108,7 @@ select { margin: 5px; }
 
 ### select box가 포함된 라벨 제공 {/*providing-a-label-for-a-select-box*/}
 
-라벨이 해당 select box와 연결되어 있음을 브라우저에 알리기 위해 [`<label>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label) 태그 안에 `<select>`를 배치합니다. 사용자가 라벨을 클릭하면 브라우저는 자동으로 선택 상자에 초점을 맞춥니다. 또한, 접근성을 위해 필수적입니다. 사용자가 select box에 초점을 맞추면 스크린 리더가 라벨 캡션을 알립니다.
+라벨이 해당 select box와 연결되어 있음을 브라우저에 알리기 위해 [`<label>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label) 태그 안에 `<select>`를 배치합니다. 사용자가 라벨을 클릭하면 브라우저는 자동으로 select box에 초점을 맞춥니다. 또한, 접근성을 위해 필수적입니다. 사용자가 select box에 초점을 맞추면 스크린 리더가 라벨 캡션을 알립니다.
 
 `<select>`를 `<label>` 안에 중첩 시킬 수 없다면, 같은 ID를 `<select id>`와 [`<label htmlFor>`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLabelElement/htmlFor)에 전달하여 연결해야 합니다. 한 컴포넌트에서 여러 인스턴스 간 충돌을 피하려면 [`useId`를 사용하여](/reference/react/useId) ID를 생성해 주세요.
 
@@ -182,7 +181,7 @@ select { margin: 5px; }
 
 <Pitfall>
 
-HTML과는 달리 개별 `<option>`에 `selected` 속성을 전달하는 것은 지원되지 않습니다.
+HTML과는 달리 개별 `<option>`에 `selected` 어트리뷰트를 전달하는 것은 지원되지 않습니다.
 
 </Pitfall>
 
@@ -229,14 +228,14 @@ select { display: block; margin-top: 10px; width: 200px; }
 ```js
 export default function EditPost() {
   function handleSubmit(e) {
-    // 브라우저에서 페이지가 다시 로드되지 않도록 설정할 수 있습니다.
+    // 브라우저가 페이지를 다시 로드하지 않도록 합니다.
     e.preventDefault();
-    // 폼 데이터 읽을 수 있습니다.
+    // 폼 데이터를 읽습니다.
     const form = e.target;
     const formData = new FormData(form);
-    // formData를 가져온 본문으로 직접 전달할 수 있습니다.
+    // formData를 fetch의 본문으로 직접 전달할 수 있습니다.
     fetch('/some-api', { method: form.method, body: formData });
-    // 브라우저가 수행하는 것처럼 URL을 생성할 수 있습니다.
+    // 브라우저의 기본 동작처럼 URL을 생성할 수 있습니다.
     console.log(new URLSearchParams(formData).toString());
     // 일반 오브젝트로 작업할 수 있습니다.
     const formJson = Object.fromEntries(formData.entries());
@@ -292,26 +291,26 @@ label { margin-bottom: 20px; }
 
 <Pitfall>
 
-기본적으로 `<form>` 내부의 *모든* `<button>`은 select box의 값을 제출합니다. 의도치 않은 동작으로 인해 당황할 수 있습니다! React 컴포넌트의 사용자 정의 `Button`이 있다면 `<button>` 대신 [`<button type="button">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/button)을 반환하는 것을 고려해야 합니다. 그런 다음 명시적으로 폼을 제출해야 하는 곳에 `<button type="submit">`을 사용해 주세요.
+기본적으로 `<form>` 내부의 *모든* `<button>`은 select box의 값을 제출합니다. 의도치 않은 동작으로 인해 당황할 수 있습니다! 사용자 정의 `Button` React 컴포넌트가 있다면 `<button>` 대신 [`<button type="button">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/button)을 반환하는 것을 고려해야 합니다. 그런 다음 명시적으로 폼을 제출해야 하는 곳에 `<button type="submit">`을 사용해 주세요.
 
 </Pitfall>
 
 ---
 
-### 상태 변수와 함께 select box 제어 {/*controlling-a-select-box-with-a-state-variable*/}
+### state 변수와 함께 select box 제어 {/*controlling-a-select-box-with-a-state-variable*/}
 
 `<select>`와 같은 select box는 *제어되지 않습니다.* `<select defaultValue="orange" />`와 같이 [처음에 선택한 값](#providing-an-initially-selected-option)을 전달하더라도 JSX는 현재 값이 아닌 초기 값만 지정합니다. 
 
-**제어된 select box를 렌더링하려면 `value` prop을 전달해야 합니다.** React는 select box가 항상 전달한 `value`를 갖도록 강제합니다. 보통 [상태 변수로 선언](/reference/react/useState)하여 선택 상자를 제어합니다.
+**제어된 select box를 렌더링하려면 `value` prop을 전달해야 합니다.** React는 select box가 항상 전달한 `value`를 갖도록 강제합니다. 보통 [state 변수로 선언](/reference/react/useState)하여 선택 상자를 제어합니다.
 
 ```js {2,6,7}
 function FruitPicker() {
-  const [selectedFruit, setSelectedFruit] = useState('orange'); // 상태 변수를 선언합니다.
+  const [selectedFruit, setSelectedFruit] = useState('orange'); // state 변수를 선언합니다.
   // ...
   return (
     <select
-      value={selectedFruit} // ...선택의 값이 상태 변수와 일치하도록 강제합니다....
-      onChange={e => setSelectedFruit(e.target.value)} // ... 변경 사항에 대해 상태 변수를 수정해 주세요!
+      value={selectedFruit} // ...select의 값이 state 변수와 일치하도록 강제합니다....
+      onChange={e => setSelectedFruit(e.target.value)} // ... 변경 사항이 있을 때마다 state 변수를 업데이트 합니다!
     >
       <option value="apple">Apple</option>
       <option value="banana">Banana</option>
@@ -377,8 +376,8 @@ select { margin-bottom: 10px; display: block; }
 
 <Pitfall>
 
-**`onChange` 없이 `value`를 전달하면 옵션을 선택할 수 없습니다.** `value`를 전달하여 select box를 제어하면 전달한 값이 항상 있도록 *강제*합니다. 따라서 `value`를 상태 변수로 전달했지만 `onChange` 이벤트 핸들러에서 상태 변수를 동기적으로 업데이트하지 않으면 React는 키를 누를 때마다 select box를 지정한 `value`로 되돌립니다.
+**`onChange` 없이 `value`를 전달하면 옵션을 선택할 수 없습니다.** `value`를 전달하여 select box를 제어하면 전달한 값이 항상 있도록 *강제*합니다. 따라서 `value`를 state 변수로 전달했지만 `onChange` 이벤트 핸들러에서 state 변수를 동기적으로 업데이트하지 않으면 React는 키를 누를 때마다 select box를 지정한 `value`로 되돌립니다.
 
-HTML과는 달리 개별 `<option>`에 `selected` 속성을 전달하는 것은 지원하지 않습니다.
+HTML과는 달리 개별 `<option>`에 `selected` 어트리뷰트를 전달하는 것은 지원하지 않습니다.
 
 </Pitfall>


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

- 번역이 누락된 props 부분을 추가했습니다.
- 기존 문서를 가이드라인에 맞춰 수정했습니다.
  - 잘못된 번역어를 수정했습니다.
  - 문장을 매끄럽게 다듬었습니다.
  - 하이퍼링크된 문서에 한글 버전이 있는 경우 한글 버전으로 수정했습니다.

-----

## Progress

- [ ] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
