### PR TITLE
[번역 누락] updating-objects-in-state 페이지의 누락된 번역

### DIFF
--- a/src/content/learn/updating-objects-in-state.md
+++ b/src/content/learn/updating-objects-in-state.md
@@ -168,7 +168,7 @@ body { margin: 0; padding: 0; height: 250px; }
 
 <DeepDive>
 
-#### Local mutation is fine {/*local-mutation-is-fine*/}
+#### 지역 변경(local mutation)은 괜찮습니다 {/*local-mutation-is-fine*/}
 
 이 코드는 state에 *존재하는* 객체를 변경하기에 문제가 됩니다.
 
@@ -375,7 +375,7 @@ input { margin-left: 5px; margin-bottom: 5px; }
 
 <DeepDive>
 
-#### Using a single event handler for multiple fields {/*using-a-single-event-handler-for-multiple-fields*/}
+#### 여러 필드에 대해 단일 이벤트 핸들러 사용하기 {/*using-a-single-event-handler-for-multiple-fields*/}
 
 `[` 와 `]` 괄호를 객체 정의 안에 사용하여 동적 이름을 가진 프로퍼티를 명시할 수 있습니다. 아래에는 이전 예제와 같지만, 세 개의 다른 이벤트 핸들러 대신 하나의 이벤트 핸들러를 사용하는 예제가 있습니다.
 
@@ -596,7 +596,7 @@ img { width: 200px; height: 200px; }
 
 <DeepDive>
 
-#### Objects are not really nested {/*objects-are-not-really-nested*/}
+#### 객체는 실제로 중첩되지 않습니다. {/*objects-are-not-really-nested*/}
 
 이러한 객체는 코드에서 "중첩되어" 나타납니다.
 
@@ -664,7 +664,7 @@ updatePerson(draft => {
 
 <DeepDive>
 
-#### How does Immer work? {/*how-does-immer-work*/}
+#### Immer는 어떻게 작동하나요? {/*how-does-immer-work*/}
 
 Immer가 제공하는 `draft`는 [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy)라고 하는 아주 특별한 객체 타입으로, 당신이 하는 일을 "기록" 합니다. 객체를 원하는 만큼 자유롭게 변경할 수 있는 이유죠! Immer는 내부적으로 `draft`의 어느 부분이 변경되었는지 알아내어, 변경사항을 포함한 완전히 새로운 객체를 생성합니다.
 
@@ -793,7 +793,7 @@ img { width: 200px; height: 200px; }
 
 <DeepDive>
 
-#### Why is mutating state not recommended in React? {/*why-is-mutating-state-not-recommended-in-react*/}
+#### 왜 React에서 상태를 직접 변경하는 것이 권장되지 않을까요? {/*why-is-mutating-state-not-recommended-in-react*/}
 
 몇 가지 이유가 있습니다.
 


### PR DESCRIPTION
# 번역 누락
[번역 누락] updating-objects-in-state 페이지의 누락된 부분을 번역하였습니다.
모두 Deep Dive의 제목 부분입니다.
[\[번역 누락\] 렌더링 그리고 커밋 페이지의 번역 누락 #831
](https://github.com/reactjs/ko.react.dev/issues/831)의 댓글에서 누락이나 픽스는 별도 이슈없이 작업해주셔도 무방하다고 하여 바로 pull request를 작성합니다.

### State를 읽기 전용인 것처럼 다루세요
번역전
![image](https://github.com/reactjs/ko.react.dev/assets/139415969/8f79cab7-ac12-4905-8b6b-35e0f6c2a790)
번역후
![image](https://github.com/reactjs/ko.react.dev/assets/139415969/0e71bff9-6e1a-4ab0-a52c-1296dcb9dd7f)


### 전개 문법으로 객체 복사하기
번역전
![image](https://github.com/reactjs/ko.react.dev/assets/139415969/faede96d-c801-4447-8cb0-b3cd6b2be16b)
번역후
![image](https://github.com/reactjs/ko.react.dev/assets/139415969/0a4d13c3-d2a7-4770-af92-ccb8476ceb63)


### 중첩된 객체 갱신하기 
번역전
![image](https://github.com/reactjs/ko.react.dev/assets/139415969/7a18da2e-bf06-4b78-a5a6-8e4324c009a1)
번역후
![image](https://github.com/reactjs/ko.react.dev/assets/139415969/ca4dc281-353b-4959-92aa-d02ae36e85df)

### Immer로 간결한 갱신 로직 작성하기
1
번역전
![image](https://github.com/reactjs/ko.react.dev/assets/139415969/91679266-8b21-4ac9-a1d4-a7fd923f6bd5)
번역후
![image](https://github.com/reactjs/ko.react.dev/assets/139415969/b5caa102-0c07-4ce2-9e83-db0a9963dd09)

2
번역전
![image](https://github.com/reactjs/ko.react.dev/assets/139415969/0c135b98-f378-466b-964f-8b9a7526a834)
번역후
![image](https://github.com/reactjs/ko.react.dev/assets/139415969/adacaa16-0eec-41b8-934d-7b24d1eb9da6)

## Progress

- [ ] 번역 초안 작성 (Draft translation)
- [X] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [ ] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [X] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [ ] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
