### PR TITLE
Fix: React로 사고하기 페이지의 ConsoleBlock 누락 수정

### DIFF
--- a/src/content/learn/thinking-in-react.md
+++ b/src/content/learn/thinking-in-react.md
@@ -435,7 +435,11 @@ td {
 
 아직 폼을 수정하는 작업이 작동하지 않음을 유의하세요. 위의 샌드박스에서 콘솔 에러가 발생하고 그 이유를 설명하겠습니다.
 
+<ConsoleBlock level="error">
+
 현재 `onChange` 핸들러 없이 폼의 필드에 `value` prop을 전달하였습니다. 이렇게 하면 읽기 전용 필드가 렌더링 됩니다.
+
+</ConsoleBlock>
 
 위에 있는 샌드박스를 보면, `ProductTable`와 `SearchBar`가 `filterText`와 `inStockOnly` props를 table, input과 체크 박스를 렌더하기 위해서 읽고 있습니다. 예를 들면, `SearchBar` input의 value를 아래와 같이 채우고 있습니다.
 

--- a/src/content/learn/thinking-in-react.md
+++ b/src/content/learn/thinking-in-react.md
@@ -437,7 +437,7 @@ td {
 
 <ConsoleBlock level="error">
 
-현재 `onChange` 핸들러 없이 폼의 필드에 `value` prop을 전달하였습니다. 이렇게 하면 읽기 전용 필드가 렌더링 됩니다.
+You provided a \`value\` prop to a form field without an \`onChange\` handler. This will render a read-only field.
 
 </ConsoleBlock>
 


### PR DESCRIPTION
close #942 
[React로 사고하기](https://ko.react.dev/learn/thinking-in-react) 페이지 내의 누락된 ConsoleBlock 요소를 추가했습니다.
동시에, 기존 번역되어있던 console의 오류 메시지를 원문으로 수정했습니다.

![CleanShot 2024-06-09 at 01 09 47@2x](https://github.com/reactjs/ko.react.dev/assets/94912717/ef2b03b5-63aa-4ec0-abf5-90a7e9126b26)

&nbsp;

+++
ConsoleBlock 내부의 문장들은 실제 console에서 보여지는 메시지인데,
번역을 해야할 지 말아야 할 지에 대한 가이드가 없는 것 같습니다.

[한글 번역 예](https://ko.react.dev/reference/react-dom/components/textarea#my-text-area-doesnt-update-when-i-type-into-it)
![CleanShot 2024-06-09 at 01 50 46@2x](https://github.com/reactjs/ko.react.dev/assets/94912717/569cf147-3daa-418d-9a91-959b9f89b107)

다른 국가들의 경우에는 번역하고 있지 않습니다.
![CleanShot 2024-06-09 at 01 58 47@2x](https://github.com/reactjs/ko.react.dev/assets/94912717/5da611b4-5d3b-49b4-b5f8-bc918d682696)
![CleanShot 2024-06-09 at 01 59 10@2x](https://github.com/reactjs/ko.react.dev/assets/94912717/2138fd63-a8ba-46df-beaa-7029503085d7)

## Progress

- [x] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
