### PR TITLE
fix: README.md typo and synchronize with react.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 ### 개발 서버 실행하기
 
-1. `yarn dev` 명령어를 사용하여 hot-reloading 개발 서버를 시작합니다. (powered by [Next.js](https://nextjs.org/))
+1. `yarn dev` 명령어를 사용하여 hot-reloading 개발 서버를 시작합니다. (powered by [Next.js](https://nextjs.org))
 1. `open http://localhost:3000` 명령어를 사용하여 선호하는 브라우저로 접속하세요.
 
 ## 기여 방법
@@ -78,4 +78,4 @@
 번역하려는 언어가 아직 진행되지 않았다면, 해당 언어에 대해 새롭게 만들 수 있습니다. [translations.react.dev repo](https://github.com/reactjs/translations.react.dev)를 참고해주세요.
 
 ## 저작권
-위 내용에 대한 저작권은 [react.dev](https://reactjs.org/)가 가지고 있으며, [LICENSE-DOCS.md](LICENSE-DOCS.md)에서 볼 수 있는 CC-BY-4.0 라이센스를 따릅니다.
+위 내용에 대한 저작권은 [react.dev](https://react.dev)가 가지고 있으며, [LICENSE-DOCS.md](LICENSE-DOCS.md)에서 볼 수 있는 CC-BY-4.0 라이센스를 따릅니다.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ko.reactjs.org
+# ko.react.dev
 
 [![](https://dcbadge.vercel.app/api/server/YXdTyCh5KF)](https://discord.gg/YXdTyCh5KF)
 
@@ -8,11 +8,11 @@
 번역을 진행할 때에 다음의 가이드를 따라주세요.
 
 1. 다음과 같은 [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md) 을 따르고 있습니다.
-2. [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation) 를 확인해주세요.
+2. [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation) 을 확인해주세요.
 3. 공통된 단어 번역을 위해 [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary) 을 참고해주세요.
 4. 마지막으로 [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/) 를 진행해주세요.
 
-이 저장소는 [reactjs.org](https://reactjs.org/)의 소스 코드와 개발 문서를 포함하고 있습니다.
+이 저장소는 [ko.react.dev](https://ko.react.dev/)의 소스 코드와 개발 문서를 포함하고 있습니다.
 
 ## 시작하기
 
@@ -26,13 +26,13 @@
 
 ### 설치
 
-1. `cd reactjs.org` 를 실행하여 프로젝트 경로로 이동합니다.
+1. `cd ko.react.dev`를 실행하여 프로젝트 경로로 이동합니다.
 1. `yarn` 을 이용하여 npm 의존성 모듈들을 설치합니다.
 
 ### 개발 서버 실행하기
 
-1. `yarn dev` 명령어를 사용하여 hot-reloading 개발 서버를 시작합니다. (powered by [Gatsby](https://www.gatsbyjs.org))
-1. `open http://localhost:8000` 명령어를 사용하여 선호하는 브라우저로 접속하세요.
+1. `yarn dev` 명령어를 사용하여 hot-reloading 개발 서버를 시작합니다. (powered by [Next.js](https://nextjs.org/))
+1. `open http://localhost:3000` 명령어를 사용하여 선호하는 브라우저로 접속하세요.
 
 ## 기여 방법
 
@@ -42,7 +42,7 @@
 
 ### 브랜치(branch) 만들기
 
-1. `reactjs.org` 로컬 저장소에서 `git checkout main`를 실행합니다.
+1. `ko.react.dev` 로컬 저장소에서 `git checkout main`을 실행합니다.
 1. `git pull origin main`를 실행하여 최신 원본 코드를 보장할 수 있습니다.
 1. `git checkout -b the-name-of-my-branch` (`the-name-of-my-branch` 를 적절한 이름으로 교체)를 실행하여 브랜치를 만듭니다.
 
@@ -50,33 +50,32 @@
 
 1. ["개발 서버 실행하기"](#개발-서버-실행하기) 부분을 따릅니다.
 1. 파일을 저장하고 브라우저에서 확인합니다.
-    1.`src`안에 있는 React 컴포넌트가 수정될 경우 hot-reload가 적용됩니다.
-    1. `content`안에 있는 마크다운 파일이 수정될 경우 hot-reload가 적용됩니다.
-    1. 플러그인을 사용하는 경우, `.cache` 디렉토리를 제거한 후 서버를 재시작해야 합니다.
+1. `src`안에 있는 React 컴포넌트가 수정될 경우 hot-reload가 적용됩니다.
+1. `content`안에 있는 마크다운 파일이 수정될 경우 hot-reload가 적용됩니다.
+1. 플러그인을 사용하는 경우, `.cache` 디렉토리를 제거한 후 서버를 재시작해야 합니다.
 
 ### 수정사항 체크하기
 
 1. 가능하다면, 변경한 부분에 대해서 많이 사용하는 브라우저의 최신 버전에서 시각적으로 제대로 적용되었는지 확인해주세요. (데스크탑과 모바일 모두)
-1. 프로젝트 루트에서 `yarn check-all`를 실행합니다. (이 명령어는 Prettier, ESLint, 그리고 Flow를 실행합니다.)
+1. 프로젝트 루트에서 `yarn check-all`을 실행합니다. (이 명령어는 Prettier, ESLint, 그리고 타입 검증을 진행합니다.)
 
 ### Push 하기
 
 1. `git add -A && git commit -m "My message"` (`My message` 부분을 `Fix header logo on Android` 같은 커밋 메시지로 교체)를 실행하여 변경한 파일들을 commit 해주세요.
-1. [reactjs.org repo](https://github.com/reactjs/reactjs.org)에서 최근에 푸시된 브랜치를 볼 수 있습니다.
+1. `git push my-fork-name the-name-of-my-branch`
+1. [ko.react.dev repo](https://github.com/reactjs/ko.react.dev)에서 최근에 푸시된 브랜치를 볼 수 있습니다.
 1. Github 지침을 따라주세요.
 1. 가능하다면 시각적으로 변화된 부분의 스크린샷을 첨부해주세요. PR을 만들고 다른사람들이 수정사항을 볼 수 있게되면 자동으로 빌드할 것입니다.
 
-## 번역
-
-`reactjs.org` 번역에 흥미가 있다면, [translations.reactjs.org](https://translations.reactjs.org/)에서 현재 번역이 얼마나 진행되었는지 확인해주세요.
-
-
-번역하려는 언어가 아직 진행되지 않았다면, 해당 언어에 대해 새롭게 만들 수 있습니다. [reactjs.org Translations](https://github.com/reactjs/reactjs.org-translation#translating-reactjsorg)를 참고해주세요.
-
 ## 문제 해결하기
 
-- `yarn reset` 명령어를 사용하여 로컬 캐시를 초기화합니다.
+`yarn reset` 명령어를 사용하여 로컬 캐시를 초기화합니다.
 
+## 번역
+
+`react.dev` 번역에 흥미가 있다면, [translations.react.dev](https://translations.react.dev/)에서 현재 번역이 얼마나 진행되었는지 확인해주세요.
+
+번역하려는 언어가 아직 진행되지 않았다면, 해당 언어에 대해 새롭게 만들 수 있습니다. [translations.react.dev repo](https://github.com/reactjs/translations.react.dev)를 참고해주세요.
 
 ## 저작권
-위 내용에 대한 저작권은 [reactjs.org](https://reactjs.org/)가 가지고 있으며, [LICENSE-DOCS.md](LICENSE-DOCS.md)에서 볼 수 있는 CC-BY-4.0 라이센스를 따릅니다.
+위 내용에 대한 저작권은 [react.dev](https://reactjs.org/)가 가지고 있으며, [LICENSE-DOCS.md](LICENSE-DOCS.md)에서 볼 수 있는 CC-BY-4.0 라이센스를 따릅니다.


### PR DESCRIPTION
`README.md` 문서를 수정하였습니다. 수정한 내용은 크게 아래와 같습니다.

1. reactjs.org -> react.dev
    - 과거 reactjs.org 대신, 최신 react.dev로 업데이트 하였습니다.

2. 영문 [README.md](https://github.com/reactjs/react.dev) 문서와 싱크를 맞추었습니다.

3. 잘못된 조사 사용 및 잘못 표기된 마크다운 부분을 수정하였습니다.

4. '문제 해결하기' 파트를 '기여하기' 파트 바로 다음으로 옮겼습니다.
    - '문제 해결하기' 부분은 코드 기여와 관련된 파트이기 때문에, '기여하기' 파트 다음에 오는 것이 좀 더 좋은 것 같습니다.

## Progress

- [ ] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
