### PR TITLE
fix: typo

### DIFF
--- a/src/sidebarLearn.json
+++ b/src/sidebarLearn.json
@@ -11,7 +11,7 @@
       "path": "/learn",
       "routes": [
         {
-          "title": "튜토리얼: Tic-Tac-Toe",
+          "title": "자습서: Tic-Tac-Toe",
           "path": "/learn/tutorial-tic-tac-toe"
         },
         {


### PR DESCRIPTION
안녕하세요, `src/sidebarLearn.json` 파일을 수정하였습니다.

[wiki](https://github.com/reactjs/ko.react.dev/wiki/Translate-Glossary)에 따라, '튜토리얼'은 '자습서'로 변경되어야 합니다.

textlint 작업 간 `.json` 파일은 따로 검사가 안되어, 부득이하게 따로 PR 올립니다😊

## Progress

- [ ] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
