### PR TITLE
fix: typo

### DIFF
--- a/src/content/learn/sharing-state-between-components.md
+++ b/src/content/learn/sharing-state-between-components.md
@@ -4,7 +4,7 @@ title: 컴포넌트 간 State 공유하기
 
 <Intro>
 
-때때로 두 컴포넌트의 state가 항상 함께 변경되기를 원할 수 있습니다. 그렇게 하려면 각 컴포넌트에서 state를 제거하고 가장 가까운 공통의 부모 컴포넌트로 옮긴 후 props로 전달해야 합니다. 이 방법을 *State 끌어올리기*라고 하며 React 코드를 작성할 때 가장 흔히 하는 일 중 하나입니다.
+때때로 두 컴포넌트의 state가 항상 함께 변경되기를 원할 수 있습니다. 그렇게 하려면 각 컴포넌트에서 state를 제거하고 가장 가까운 공통 부모 컴포넌트로 옮긴 후 props로 전달해야 합니다. 이 방법을 *State 끌어올리기*라고 하며 React 코드를 작성할 때 가장 흔히 하는 일 중 하나입니다.
 
 </Intro>
 
@@ -96,8 +96,8 @@ h3, p { margin: 5px 0px; }
 두 패널을 조정하려면 다음 세 단계를 통해 부모 컴포넌트로 패널의 "State 끌어올리기"가 필요합니다.
 
 1. 자식 컴포넌트의 state를 **제거**합니다.
-2. 하드 코딩된 값을 공통의 부모로부터 **전달**합니다.
-3. 공통의 부모에 state를 **추가**하고 이벤트 핸들러와 함께 전달합니다.
+2. 하드 코딩된 값을 공통 부모로부터 **전달**합니다.
+3. 공통 부모에 state를 **추가**하고 이벤트 핸들러와 함께 전달합니다.
 
 이 방법으로 `Accordion` 컴포넌트가 두 `Panel`을 조정하고 한 번에 하나만 열리도록 할 수 있습니다.
 
@@ -178,7 +178,7 @@ h3, p { margin: 5px 0px; }
 
 상태 끌어올리기는 종종 state로 저장하고 있는 것의 특성을 바꿉니다.
 
-이 케이스에서는, 한 번에 하나의 패널만 활성화되어야 합니다. 이를 위해 공통 부모 컴포넌트인 `Accordian`은 *어떤* 패널이 활성화된 패널인지 추적하고 있어야 합니다. state 변수에 `boolean` 값을 사용하는 대신, 활성화되어있는 `Panel`의 인덱스 숫자를 사용할 수 있습니다:
+이 케이스에서는, 한 번에 하나의 패널만 활성화되어야 합니다. 이를 위해 공통 부모 컴포넌트인 `Accordian`은 *어떤* 패널이 활성화된 패널인지 추적하고 있어야 합니다. state 변수에 `boolean` 값을 사용하는 대신, 활성화되어있는 `Panel`의 인덱스 숫자를 사용할 수 있습니다.
 
 ```js
 const [activeIndex, setActiveIndex] = useState(0);
@@ -186,7 +186,7 @@ const [activeIndex, setActiveIndex] = useState(0);
 
 `activeIndex`가 `0`이면 첫 번째 패널이 활성화된 것이고, `1`이면 두 번째 패널이 활성화된 것입니다.
 
-각 `Panel`에서 "Show 버튼을 클릭하면 `Accordion`의 활성화된 인덱스를 변경해야 합니다. `activeIndex` state는 `Accordion` 내에서 정의되었기 때문에 `Panel`은 값을 직접 설정할 수 없습니다. `Accordion` 컴포넌트는 `Panel` 컴포넌트가 state를 변경할 수 있음을 [이벤트 핸들러를 prop으로 전달하기](/learn/responding-to-events#passing-event-handlers-as-props)를 통해 *명시적으로 허용*해야 합니다.
+각 `Panel`에서 "Show" 버튼을 클릭하면 `Accordion`의 활성화된 인덱스를 변경해야 합니다. `activeIndex` state는 `Accordion` 내에서 정의되었기 때문에 `Panel`은 값을 직접 설정할 수 없습니다. `Accordion` 컴포넌트는 `Panel` 컴포넌트가 state를 변경할 수 있음을 [이벤트 핸들러를 prop으로 전달하기](/learn/responding-to-events#passing-event-handlers-as-props)를 통해 *명시적으로 허용*해야 합니다.
 
 ```js
 <>
@@ -272,7 +272,7 @@ h3, p { margin: 5px 0px; }
 
 <Diagram name="sharing_state_parent" height={385} width={487} alt="Accordion이라는 이름의 하나의 부모와 Panel이라는 이름의 두 자식으로 구성된 세 컴포넌트 트리를 나타내는 다이어그램입니다. Accordion은 값이 0인 activeIndex를 가지며, 첫 번째 패널의 isActive에 true를, 두 번째 패널의 isActive에 false를 반환합니다." >
 
-처음에 `Accordion`의 `activeIndex`는 0이고, 따라서 첫 번째 `Panel`은 `isActive = true`를 받습니다.
+처음에 `Accordion`의 `activeIndex`는 `0`이므로 첫 번째 `Panel`은 `isActive = true`를 받습니다.
 
 </Diagram>
 


### PR DESCRIPTION
안녕하세요, `learn/sharing-state-between-components.md` 문서를 일부 수정하였습니다.

1. 공통의 부모 -> 공통 부모
    - 같은 용어가 문서의 아래쪽에서는 '공통 부모'로 번역되어 있고, 위쪽에서는 '공통의 부모'로 번역되어 있어, 일관성을 유지하도록 수정하였습니다.
    - 또한, '최소 공통 조상(Lowest Common Ancestor)' 등의 알고리즘에서도 그렇고, 일반적으로 CS에서는 common parents를 '공통 부모'라고 번역합니다.

2. 인덱스 숫자를 사용할 수 있습니다:
    - wiki에 따라, 문장 끝 콜론을 마침표로 변경하였습니다.

3. “Show -> "Show"
    - 큰따옴표가 짝이 맞지 않아 수정하였습니다. (영어 원문을 기준으로 수정한 것입니다.)

4. 처음에 Accordion의 activeIndex는 0이고, 따라서 첫 번째 Panel은 isActive = true를 받습니다. 
    - '이고, 따라서'를 '이므로' 로 변경하여, 문장의 어색함을 수정하였습니다.
    - 숫자 0은 코드 상의 값이므로, 인라인 코드 블럭으로 감싸져야 합니다. (바로 아래 문장의 숫자 1은 인라인 코드블럭으로 감싸져 있습니다.)

## Progress

- [ ] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
