### PR TITLE
fix: correct mistranslation

### DIFF
--- a/src/content/learn/you-might-not-need-an-effect.md
+++ b/src/content/learn/you-might-not-need-an-effect.md
@@ -619,7 +619,7 @@ React에서 데이터는 부모 컴포넌트에서 자식 컴포넌트로 흐릅
 function Parent() {
   const data = useSomeAPI();
   // ...
-  // ✅ 좋습니다: 자식에서 데이터를 전달
+  // ✅ 좋습니다: 자식에게 데이터 전달하기
   return <Child data={data} />;
 }
 


### PR DESCRIPTION
>React에서 데이터는 부모 컴포넌트에서 자식 컴포넌트로 흐릅니다.  ...<생략>... 자식과 부모 모두 동일한 데이터가 필요하므로 부모 컴포넌트가 해당 데이터를 가져와서 자식에게 대신 내려주도록 하세요.

>이렇게 하면 데이터가 부모에서 자식으로 내려오기 때문에 데이터 흐름이 더 간단하고 예측 가능하게 유지됩니다.

위의 내용과 영어 원문으로 미루어 볼 때, 부모가 자식에게 데이터를 전달하는 것이므로 자식"에서"가 아닌 자식"에게"가 올바른 번역인 것 같습니다.

그리고 같은 글에서
>Effect에서 부모에게 데이터 전달하기

와 같은 식으로 주석이 작성되어 있어 문장을 그와 같은 방식으로 다듬었습니다.

### 영어 원문
![image](https://github.com/user-attachments/assets/608cd9c6-846b-4fe5-8e82-97e68d353de5)



## Progress

- [ ] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.reactjs.org/blob/master/UNIVERSAL-STYLE-GUIDE.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.reactjs.org/wiki/Best-practices-for-translation)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.reactjs.org/wiki/Translate-Glossary)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
