### PR TITLE
build: bump `actions/upload-artifact` from `v2` to `v4`

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -41,13 +41,13 @@ jobs:
         run: npx -p nextjs-bundle-analysis@0.5.0 report
 
       - name: Upload bundle
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: .next/analyze/__bundle_analysis.json
           name: bundle_analysis.json
 
       - name: Download base branch bundle stats
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v4
         if: success() && github.event.number
         with:
           workflow: analyze.yml
@@ -73,7 +73,7 @@ jobs:
         run: ls -laR .next/analyze/base && npx -p nextjs-bundle-analysis compare
 
       - name: Upload analysis comment
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: analysis_comment.txt
           path: .next/analyze/__bundle_analysis_comment.txt
@@ -82,7 +82,7 @@ jobs:
         run: echo ${{ github.event.number }} > ./pr_number
 
       - name: Upload PR number
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pr_number
           path: ./pr_number


### PR DESCRIPTION
안녕하세요😊 `actions/upload-artifact@v2`가 deprecated 됨에 따라 아래와 같이 오류가 발생하여 버전을 올려서 PR 합니다.

https://github.com/actions/upload-artifact

공식 문서에서는 6월 30일자로 `v2`가 deprecated 되었다고 적혀있습니다.

현재 이슈로 #1044 의 CI가 통과되지 못하고 있습니다.

![image](https://github.com/user-attachments/assets/009f2f3b-ab5c-4ec9-a045-213e945dd893)

@hg-pyun 