### PR TITLE
perf: update regexp in translateGlossary.js

### DIFF
--- a/textlint/data/rules/translateGlossary.js
+++ b/textlint/data/rules/translateGlossary.js
@@ -2,7 +2,7 @@ module.exports = {
   translated: {
     react: [
       {
-        sources: [/Tutorial/, /[듀튜]토리얼/],
+        sources: [/\bTutorial\b/, /[듀튜]토리얼/],
         target: '자습서',
         meta: {
           term: 'Tutorial',
@@ -11,7 +11,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Declarative/],
+        sources: [/\bDeclarative\b/],
         target: '선언적인',
         meta: {
           term: 'Declarative',
@@ -20,7 +20,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Component/, /컴퍼넌트/, /컴포넌츠/],
+        sources: [/\bComponent\b/, /컴퍼넌트/, /컴포넌츠/],
         target: '컴포넌트',
         meta: {
           term: 'Component',
@@ -29,7 +29,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Stateful/],
+        sources: [/\bStateful\b/],
         target: '유상태',
         meta: {
           term: 'Stateful',
@@ -38,7 +38,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Stateless/],
+        sources: [/\bStateless\b/],
         target: '무상태',
         meta: {
           term: 'Stateless',
@@ -48,7 +48,7 @@ module.exports = {
       },
       {
         sources: [
-          /Render(?!er)(?:ing)?/,
+          /\bRender(?!er)(?:ing)?\b/,
           /랜더링/,
           /[렌랜]더(?!링)\s?[하한할함합]/,
         ],
@@ -60,7 +60,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Data/, /대이터/],
+        sources: [/\bData\b/, /대이터/],
         target: '데이터',
         meta: {
           term: 'Data',
@@ -69,7 +69,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Application/, /어플리케이[선션]/, /응용\s?프로그램/],
+        sources: [/\bApplication\b/, /어플리케이[선션]/, /응용\s?프로그램/],
         target: '애플리케이션',
         meta: {
           term: 'Application',
@@ -78,7 +78,7 @@ module.exports = {
         },
       },
       {
-        sources: [/External/],
+        sources: [/\bExternal\b/],
         target: '외부',
         meta: {
           term: 'External',
@@ -87,7 +87,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Plugin/],
+        sources: [/\bPlugin\b/],
         target: '플러그인',
         meta: {
           term: 'Plugin',
@@ -96,7 +96,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Third/, /써드/],
+        sources: [/\bThird\b/, /써드/],
         target: '서드',
         meta: {
           term: 'Third',
@@ -105,7 +105,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Syntax/, /[신씬]택스/],
+        sources: [/\bSyntax\b/, /[신씬]택스/],
         target: '문법',
         meta: {
           term: 'Syntax',
@@ -114,7 +114,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Embedding\s?Expression/],
+        sources: [/\bEmbedding\s?Expression\b/],
         target: '표현식 포함하기',
         meta: {
           term: 'Embedding Expression',
@@ -123,7 +123,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Attribute/, /애트리뷰트/],
+        sources: [/\bAttribute\b/, /애트리뷰트/],
         target: '어트리뷰트',
         meta: {
           term: 'Attribute',
@@ -132,7 +132,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Element/, /[엘앨]리먼츠/, /앨리먼트/],
+        sources: [/\bElement\b/, /[엘앨]리먼츠/, /앨리먼트/],
         target: '엘리먼트',
         meta: {
           term: 'Element',
@@ -141,7 +141,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Function/, /Functional/],
+        sources: [/\bFunction(?:al)?\b/],
         target: '함수',
         meta: {
           term: 'Function',
@@ -150,7 +150,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Class/],
+        sources: [/\bClass\b/],
         target: '클래스',
         meta: {
           term: 'Class',
@@ -159,7 +159,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Composition/, /[컴콤][퍼포]지[선션]/],
+        sources: [/\bComposition\b/, /[컴콤][퍼포]지[선션]/],
         target: '합성',
         meta: {
           term: 'Composition',
@@ -168,7 +168,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Inheritance/],
+        sources: [/\bInheritance\b/],
         target: '상속',
         meta: {
           term: 'Inheritance',
@@ -177,7 +177,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Life\s?Cycle/, /라이프\s?사이클/, /생명 주기/],
+        sources: [/\bLife\s?Cycle\b/, /라이프\s?사이클/, /생명 주기/],
         target: '생명주기',
         meta: {
           term: 'Lifecycle',
@@ -186,7 +186,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Handling/, /핸들링/],
+        sources: [/\bHandling\b/, /핸들링/],
         target: '처리',
         meta: {
           term: 'Handling',
@@ -195,7 +195,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Conditional/, /컨디[서셔][날널]/],
+        sources: [/\bConditional\b/, /컨디[서셔][날널]/],
         target: '조건부',
         meta: {
           term: 'Conditional',
@@ -204,7 +204,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Operator/, /오퍼[레래]이터/],
+        sources: [/\bOperator\b/, /오퍼[레래]이터/],
         target: '연산자',
         meta: {
           term: 'Operator',
@@ -213,7 +213,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Reuse/],
+        sources: [/\bReuse\b/],
         target: '재사용',
         meta: {
           term: 'Reuse',
@@ -222,7 +222,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Mock/],
+        sources: [/\bMock\b/],
         target: '모의',
         meta: {
           term: 'Mock',
@@ -231,7 +231,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Callback/],
+        sources: [/\bCallback\b/],
         target: '콜백',
         meta: {
           term: 'Callback',
@@ -240,7 +240,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Synthetic/],
+        sources: [/\bSynthetic\b/],
         target: '합성',
         meta: {
           term: 'Synthetic',
@@ -249,7 +249,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Event/],
+        sources: [/\bEvent\b/],
         target: '이벤트',
         meta: {
           term: 'Event',
@@ -258,7 +258,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Higher\s?Order/],
+        sources: [/\bHigher\s?Order\b/],
         target: '고차',
         meta: {
           term: 'Higher Order',
@@ -267,7 +267,7 @@ module.exports = {
         },
       },
       {
-        sources: [/(?<!Un)Mount/],
+        sources: [/\b(?<!Un)Mount\b/],
         target: '마운트',
         meta: {
           term: 'Mount',
@@ -276,7 +276,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Unmount/, /언마운트/],
+        sources: [/\bUnmount\b/, /언마운트/],
         target: '마운트 해제',
         meta: {
           term: 'Unmount',
@@ -285,7 +285,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Form/],
+        sources: [/\bForm\b/],
         target: '폼',
         meta: {
           term: 'Form',
@@ -294,7 +294,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Wrapper/],
+        sources: [/\bWrapper\b/],
         target: '래퍼',
         meta: {
           term: 'Wrapper',
@@ -303,7 +303,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Child(?:ren)?/],
+        sources: [/\bChild(?:ren)?\b/],
         target: '자식',
         meta: {
           term: 'Children',
@@ -312,7 +312,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Code[-\s]?Splitting/],
+        sources: [/\bCode[-\s]?Splitting\b/],
         target: '코드 분할',
         meta: {
           term: 'Code-Splitting',
@@ -321,7 +321,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Reconciliation/],
+        sources: [/\bReconciliation\b/],
         target: '재조정',
         meta: {
           term: 'Reconciliation',
@@ -330,7 +330,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Propert(?:y|ies)/],
+        sources: [/\bPropert(?:y|ies)\b/],
         target: '프로퍼티',
         meta: {
           term: 'Property',
@@ -339,7 +339,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Reference/, /래퍼런스/],
+        sources: [/\bReference\b/, /래퍼런스/],
         target: '레퍼런스',
         meta: {
           term: 'Reference',
@@ -348,7 +348,7 @@ module.exports = {
         },
       },
       {
-        sources: [/User/, /유저/],
+        sources: [/\bUser\b/, /유저/],
         target: '사용자',
         meta: {
           term: 'User',
@@ -357,7 +357,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Interface/],
+        sources: [/\bInterface\b/],
         target: '인터페이스',
         meta: {
           term: 'Interface',
@@ -366,7 +366,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Markup/, /마크 업/],
+        sources: [/\bMarkup\b/, /마크 업/],
         target: '마크업',
         meta: {
           term: 'Markup',
@@ -375,7 +375,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Interacti(?:vity|on)/, /인터[랙렉][선션]/],
+        sources: [/\bInteracti(?:vity|on)\b/, /인터[랙렉][선션]/],
         target: '상호작용',
         meta: {
           term: 'Interactivity',
@@ -384,7 +384,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Architecture/, /아키택처/, /아키[택텍]쳐/],
+        sources: [/\bArchitecture\b/, /아키택처/, /아키[택텍]쳐/],
         target: '아키텍처',
         meta: {
           term: 'Architecture',
@@ -393,7 +393,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Full[-\s]?Stack/],
+        sources: [/\bFull[-\s]?Stack\b/],
         target: '풀스택',
         meta: {
           term: 'Full-Stack',
@@ -402,7 +402,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Browser/],
+        sources: [/\bBrowser\b/],
         target: '브라우저',
         meta: {
           term: 'Browser',
@@ -411,7 +411,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Extension/, /확장프로그램/],
+        sources: [/\bExtension\b/, /확장프로그램/],
         target: '확장 프로그램',
         meta: {
           term: 'Extension',
@@ -420,7 +420,7 @@ module.exports = {
         },
       },
       {
-        sources: [/Escape[-\s]?Hatches/],
+        sources: [/\bEscape[-\s]?Hatches\b/],
         target: '탈출구',
         meta: {
           term: 'Escape Hatches',

--- a/wiki/translate-glossary.md
+++ b/wiki/translate-glossary.md
@@ -8,53 +8,53 @@
 
 용어 `term`|정규표현식 `sources`|번역 `target`|논의 `discussions`|비고 `note`|
 ---|---|---|---|---|
-Tutorial|`/Tutorial/`, `/[듀튜]토리얼/`|자습서|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Declarative|`/Declarative/`|선언적인|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Component|`/Component/`, `/컴퍼넌트/`, `/컴포넌츠/`|컴포넌트|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Stateful|`/Stateful/`|유상태|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Stateless|`/Stateless/`|무상태|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Render|`/Render(?!er)(?:ing)?/`, `/랜더링/`, `/[렌랜]더(?!링)\s?[하한할함합]/`|렌더링(하다)|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Data|`/Data/`, `/대이터/`|데이터|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Application|`/Application/`, `/어플리케이[선션]/`, `/응용\s?프로그램/`|애플리케이션|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-External|`/External/`|외부|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Plugin|`/Plugin/`|플러그인|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Third|`/Third/`, `/써드/`|서드|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Syntax|`/Syntax/`, `/[신씬]택스/`|문법|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Embedding Expression|`/Embedding\s?Expression/`|표현식 포함하기|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Attribute|`/Attribute/`, `/애트리뷰트/`|어트리뷰트|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Element|`/Element/`, `/[엘앨]리먼츠/`, `/앨리먼트/`|엘리먼트|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Function|`/Function/`, `/Functional/`|함수|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Class|`/Class/`|클래스|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Composition|`/Composition/`, `/[컴콤][퍼포]지[선션]/`|합성|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Inheritance|`/Inheritance/`|상속|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Lifecycle|`/Life\s?Cycle/`, `/라이프\s?사이클/`, `/생명 주기/`|생명주기|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Handling|`/Handling/`, `/핸들링/`|처리|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Conditional|`/Conditional/`, `/컨디[서셔][날널]/`|조건부|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Operator|`/Operator/`, `/오퍼[레래]이터/`|연산자|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Reuse|`/Reuse/`|재사용|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Mock|`/Mock/`|모의|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Callback|`/Callback/`|콜백|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Synthetic|`/Synthetic/`|합성|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Event|`/Event/`|이벤트|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Higher Order|`/Higher\s?Order/`|고차|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Mount|`/(?<!Un)Mount/`|마운트|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Unmount|`/Unmount/`, `/언마운트/`|마운트 해제|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Form|`/Form/`|폼|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Wrapper|`/Wrapper/`|래퍼|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Children|`/Child(?:ren)?/`|자식|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Code-Splitting|`/Code[-\s]?Splitting/`|코드 분할|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Reconciliation|`/Reconciliation/`|재조정|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Property|`/Propert(?:y\|ies)/`|프로퍼티|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
-Reference|`/Reference/`, `/래퍼런스/`|레퍼런스|[#569](https://github.com/reactjs/ko.react.dev/issues/569)||
-User|`/User/`, `/유저/`|사용자|[#569](https://github.com/reactjs/ko.react.dev/issues/569)||
-Interface|`/Interface/`|인터페이스|[#569](https://github.com/reactjs/ko.react.dev/issues/569)||
-Markup|`/Markup/`, `/마크 업/`|마크업|[#569](https://github.com/reactjs/ko.react.dev/issues/569)||
-Interactivity|`/Interacti(?:vity\|on)/`, `/인터[랙렉][선션]/`|상호작용|[#569](https://github.com/reactjs/ko.react.dev/issues/569)||
-Architecture|`/Architecture/`, `/아키택처/`, `/아키[택텍]쳐/`|아키텍처|[#569](https://github.com/reactjs/ko.react.dev/issues/569)||
-Full-Stack|`/Full[-\s]?Stack/`|풀스택|[#569](https://github.com/reactjs/ko.react.dev/issues/569)||
-Browser|`/Browser/`|브라우저|[#610](https://github.com/reactjs/ko.react.dev/issues/610)||
-Extension|`/Extension/`, `/확장프로그램/`|확장 프로그램|[#610](https://github.com/reactjs/ko.react.dev/issues/610)||
-Escape Hatches|`/Escape[-\s]?Hatches/`|탈출구|[#738](https://github.com/reactjs/ko.react.dev/issues/738)||
+Tutorial|`/\bTutorial\b/`, `/[듀튜]토리얼/`|자습서|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Declarative|`/\bDeclarative\b/`|선언적인|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Component|`/\bComponent\b/`, `/컴퍼넌트/`, `/컴포넌츠/`|컴포넌트|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Stateful|`/\bStateful\b/`|유상태|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Stateless|`/\bStateless\b/`|무상태|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Render|`/\bRender(?!er)(?:ing)?\b/`, `/랜더링/`, `/[렌랜]더(?!링)\s?[하한할함합]/`|렌더링(하다)|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Data|`/\bData\b/`, `/대이터/`|데이터|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Application|`/\bApplication\b/`, `/어플리케이[선션]/`, `/응용\s?프로그램/`|애플리케이션|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+External|`/\bExternal\b/`|외부|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Plugin|`/\bPlugin\b/`|플러그인|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Third|`/\bThird\b/`, `/써드/`|서드|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Syntax|`/\bSyntax\b/`, `/[신씬]택스/`|문법|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Embedding Expression|`/\bEmbedding\s?Expression\b/`|표현식 포함하기|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Attribute|`/\bAttribute\b/`, `/애트리뷰트/`|어트리뷰트|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Element|`/\bElement\b/`, `/[엘앨]리먼츠/`, `/앨리먼트/`|엘리먼트|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Function|`/\bFunction(?:al)?\b/`|함수|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Class|`/\bClass\b/`|클래스|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Composition|`/\bComposition\b/`, `/[컴콤][퍼포]지[선션]/`|합성|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Inheritance|`/\bInheritance\b/`|상속|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Lifecycle|`/\bLife\s?Cycle\b/`, `/라이프\s?사이클/`, `/생명 주기/`|생명주기|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Handling|`/\bHandling\b/`, `/핸들링/`|처리|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Conditional|`/\bConditional\b/`, `/컨디[서셔][날널]/`|조건부|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Operator|`/\bOperator\b/`, `/오퍼[레래]이터/`|연산자|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Reuse|`/\bReuse\b/`|재사용|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Mock|`/\bMock\b/`|모의|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Callback|`/\bCallback\b/`|콜백|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Synthetic|`/\bSynthetic\b/`|합성|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Event|`/\bEvent\b/`|이벤트|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Higher Order|`/\bHigher\s?Order\b/`|고차|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Mount|`/\b(?<!Un)Mount\b/`|마운트|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Unmount|`/\bUnmount\b/`, `/언마운트/`|마운트 해제|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Form|`/\bForm\b/`|폼|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Wrapper|`/\bWrapper\b/`|래퍼|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Children|`/\bChild(?:ren)?\b/`|자식|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Code-Splitting|`/\bCode[-\s]?Splitting\b/`|코드 분할|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Reconciliation|`/\bReconciliation\b/`|재조정|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Property|`/\bPropert(?:y\|ies)\b/`|프로퍼티|[#2](https://github.com/reactjs/ko.react.dev/issues/2)||
+Reference|`/\bReference\b/`, `/래퍼런스/`|레퍼런스|[#569](https://github.com/reactjs/ko.react.dev/issues/569)||
+User|`/\bUser\b/`, `/유저/`|사용자|[#569](https://github.com/reactjs/ko.react.dev/issues/569)||
+Interface|`/\bInterface\b/`|인터페이스|[#569](https://github.com/reactjs/ko.react.dev/issues/569)||
+Markup|`/\bMarkup\b/`, `/마크 업/`|마크업|[#569](https://github.com/reactjs/ko.react.dev/issues/569)||
+Interactivity|`/\bInteracti(?:vity\|on)\b/`, `/인터[랙렉][선션]/`|상호작용|[#569](https://github.com/reactjs/ko.react.dev/issues/569)||
+Architecture|`/\bArchitecture\b/`, `/아키택처/`, `/아키[택텍]쳐/`|아키텍처|[#569](https://github.com/reactjs/ko.react.dev/issues/569)||
+Full-Stack|`/\bFull[-\s]?Stack\b/`|풀스택|[#569](https://github.com/reactjs/ko.react.dev/issues/569)||
+Browser|`/\bBrowser\b/`|브라우저|[#610](https://github.com/reactjs/ko.react.dev/issues/610)||
+Extension|`/\bExtension\b/`, `/확장프로그램/`|확장 프로그램|[#610](https://github.com/reactjs/ko.react.dev/issues/610)||
+Escape Hatches|`/\bEscape[-\s]?Hatches\b/`|탈출구|[#738](https://github.com/reactjs/ko.react.dev/issues/738)||
 
 ### Others
 


### PR DESCRIPTION
안녕하세요😊

textlint를 통한 검사를 진행할 때 사용하던 기존 정규표현식을 더욱 정확하게 동작하도록 업데이트 하였습니다.

수정 내역은 아래와 같습니다.

1. `\b` 기호를 추가하여 단어 간 경계를 더욱 명확하게 하였습니다.
2. 불필요하게 2개 이상의 정규표현식으로 나뉘어 있던 정규표현식들을 하나로 합쳤습니다.
3. `wiki/translateGlossary.md`는 자동으로 업데이트 되었습니다.

## Progress

- [ ] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [모범사례 확인 (Check best practices)](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [맞춤법 검사 (Spelling check)](http://speller.cs.pusan.ac.kr/)
- [ ] 리뷰 반영 (Resolve reviews)
