### PR TITLE
docs: add explanation for missing y property case

### DIFF
--- a/src/content/learn/choosing-the-state-structure.md
+++ b/src/content/learn/choosing-the-state-structure.md
@@ -98,7 +98,7 @@ body { margin: 0; padding: 0; height: 250px; }
 
 <Pitfall>
 
-State 변수가 객체인 경우에는 다른 필드를 명시적으로 복사하지 않고 [하나의 필드만 업데이트할 수 없다](/learn/updating-objects-in-state)는 것을 기억하세요. 예를 들어, 위의 예시에서는 `y` 속성이 전혀 없기 때문입니다. `setPosition({ x: 100 })`를 할 수 없습니다! 대신, `x`만 설정하려면 `setPosition({ ...position, x: 100 })`을 하거나 두 개의 state 변수로 나누고 `setX(100)`을 해야 합니다.
+State 변수가 객체인 경우에는 다른 필드를 명시적으로 복사하지 않고 [하나의 필드만 업데이트할 수 없다](/learn/updating-objects-in-state)는 것을 기억하세요. 예를 들어 위의 예시에서 `setPosition({ x: 100 })`은 `y` 속성이 존재하지 않기 때문에 사용할 수 없습니다! 대신, `x`만 설정하려면 `setPosition({ ...position, x: 100 })`을 하거나 두 개의 state 변수로 나누고 `setX(100)`을 해야 합니다.
 
 </Pitfall>
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
안녕하세요!

공식 문서에 글의 흐름이 어색한 부분이 있어 수정했습니다. setPosition({ x: 100 }) 은 y 속성이 없기 때문에 사용할 수 없다는 의미가 명확히 전달되도록 문장을 수정했습니다. 또한 국어 맞춤법에 맞춰 '예를 들어' 뒤에 있는 쉼표를 제거했습니다.

기존 : 예를 들어, 위의 예시에서는 y 속성이 전혀 없기 때문입니다. setPosition({ x: 100 })를 할 수 없습니다!

수정 → 예를 들어 위의 예시에서 setPosition({ x: 100 })은 y 속성이 존재하지 않기 때문에 사용할 수 없습니다!

<img width="785" alt="스크린샷 2024-10-24 오후 11 42 39" src="https://github.com/user-attachments/assets/ee2f91d9-ddfa-4ca5-976d-e3565340ce0d">

도움 주신 분 : [lumirlumir](https://github.com/lumirlumir) 님 감사합니다!
## Progress

- [ ] 번역 초안 작성 (Draft translation)
- [x] [공통 스타일 가이드 확인 (Check the common style guide)](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [모범 사례 확인 (Check best practices)](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [용어 확인 (Check the term)](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [Textlint 가이드 확인 (Check the textlint guide)](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint/what-is-textlint.md)
- [x] [맞춤법 검사 (Spelling check)](https://nara-speller.co.kr/speller/)
- [x] 리뷰 반영 (Resolve reviews)
