### PR TITLE
docs: translate passing-data-deeply-with-context in react-learn

### DIFF
--- a/src/content/learn/passing-data-deeply-with-context.md
+++ b/src/content/learn/passing-data-deeply-with-context.md
@@ -570,10 +570,6 @@ export const LevelContext = createContext(1);
 2. `Section`은 자식을 `<LevelContext.Provider value={level}>`로 감싸줍니다.
 3. `Heading`은 `useContext(LevelContext)`를 사용해 가장 근처의 `LevelContext`의 값을 요청합니다.
 
-1. You pass a `level` prop to the `<Section>`.
-2. `Section` wraps its children into `<LevelContext value={level}>`.
-3. `Heading` asks the closest value of `LevelContext` above with `useContext(LevelContext)`.
-
 ## 같은 컴포넌트에서 context를 사용하며 제공하기 {/*using-and-providing-context-from-the-same-component*/}
 
 지금은 각각의 섹션에 `level`을 수동으로 지정해야 합니다.

--- a/src/content/learn/passing-data-deeply-with-context.md
+++ b/src/content/learn/passing-data-deeply-with-context.md
@@ -476,7 +476,7 @@ export default function Section({ level, children }) {
 }
 ```
 
-이것은 React에게 `Section` 내의 어떤 컴포넌트가 `LevelContext`를 요구하면 `level`을 주라고 알려줍니다. 컴포넌트는 그 위에 있는 UI 트리에서 가장 가까운 `<LevelContext.Provider>`의 값을 사용합니다.
+이것은 React에게 `<Section>` 내의 어떤 컴포넌트가 `LevelContext`를 요구하면 `level`을 주라고 알려줍니다. 컴포넌트는 그 위에 있는 UI 트리에서 가장 가까운 `<LevelContext>`의 값을 사용합니다.
 
 <Sandpack>
 
@@ -567,7 +567,7 @@ export const LevelContext = createContext(1);
 기존 코드와 동일한 결과이지만 `level` prop을 각 `Heading` 컴포넌트에 전달할 필요는 없습니다! 대신 위의 가장 가까운 `Section`에게 제목 레벨을 "확인"합니다.
 
 1. `level` prop 을 `<Section>`에 전달합니다.
-2. `Section`은 자식을 `<LevelContext.Provider value={level}>`로 감싸줍니다.
+2. `Section`은 자식을 `<LevelContext value={level}>`로 감싸줍니다.
 3. `Heading`은 `useContext(LevelContext)`를 사용해 가장 근처의 `LevelContext`의 값을 요청합니다.
 
 ## 같은 컴포넌트에서 context를 사용하며 제공하기 {/*using-and-providing-context-from-the-same-component*/}
@@ -868,7 +868,7 @@ Context는 정적인 값으로 제한되지 않습니다. 다음 렌더링 시 �
 - Context를 전달하려면 다음과 같습니다
   1. `export const MyContext = createContext(defaultValue)`로 context를 생성하고 내보내세요.
   2. `useContext(MyContext)` Hook에 전달해 얼마나 깊이 있든 자식 컴포넌트가 읽을 수 있도록 합니다.
-  3. 자식을 `<MyContext.Provider value={...}>`로 감싸 부모로부터 context를 받도록 합니다.
+  3. 자식을 `<MyContext value={...}>`로 감싸 부모로부터 context를 받도록 합니다.
 - Context는 중간의 어떤 컴포넌트도 지나갈 수 있습니다.
 - Context를 활용해 "주변에 적응하는" 컴포넌트를 작성할 수 있습니다.
 - Context를 사용하기 전에 props를 전달하거나 JSX를 `children`으로 전달하는 것을 먼저 시도해보세요.

--- a/src/content/learn/passing-data-deeply-with-context.md
+++ b/src/content/learn/passing-data-deeply-with-context.md
@@ -214,13 +214,13 @@ Context는 부모가 트리 내부 전체에, 심지어 멀리 떨어진 컴포�
 
 <Diagram name="passing_data_context_close" height={160} width={608} captionPosition="top" alt="Diagram with a tree of three components. The parent contains a bubble representing a value highlighted in orange which projects down to the two children, each highlighted in orange." >
 
-Using context in close children
+Context를 가까운 자식 컴포넌트에서 사용하기
 
 </Diagram>
 
 <Diagram name="passing_data_context_far" height={430} width={608} captionPosition="top" alt="Diagram with a tree of ten nodes, each node with two children or less. The root parent node contains a bubble representing a value highlighted in orange. The value projects down directly to four leaves and one intermediate component in the tree, which are all highlighted in orange. None of the other intermediate components are highlighted.">
 
-Using context in distant children
+Context를 먼 자식 컴포넌트에서 사용하기
 
 </Diagram>
 

--- a/src/content/learn/passing-data-deeply-with-context.md
+++ b/src/content/learn/passing-data-deeply-with-context.md
@@ -478,8 +478,6 @@ export default function Section({ level, children }) {
 
 이것은 React에게 `Section` 내의 어떤 컴포넌트가 `LevelContext`를 요구하면 `level`을 주라고 알려줍니다. 컴포넌트는 그 위에 있는 UI 트리에서 가장 가까운 `<LevelContext.Provider>`의 값을 사용합니다.
 
-This tells React: "if any component inside this `<Section>` asks for `LevelContext`, give them this `level`." The component will use the value of the nearest `<LevelContext>` in the UI tree above it.
-
 <Sandpack>
 
 ```js

--- a/src/content/learn/passing-data-deeply-with-context.md
+++ b/src/content/learn/passing-data-deeply-with-context.md
@@ -873,15 +873,6 @@ Context는 정적인 값으로 제한되지 않습니다. 다음 렌더링 시 �
 - Context를 활용해 "주변에 적응하는" 컴포넌트를 작성할 수 있습니다.
 - Context를 사용하기 전에 props를 전달하거나 JSX를 `children`으로 전달하는 것을 먼저 시도해보세요.
 
-* Context lets a component provide some information to the entire tree below it.
-* To pass context:
-  1. Create and export it with `export const MyContext = createContext(defaultValue)`.
-  2. Pass it to the `useContext(MyContext)` Hook to read it in any child component, no matter how deep.
-  3. Wrap children into `<MyContext value={...}>` to provide it from a parent.
-* Context passes through any components in the middle.
-* Context lets you write components that "adapt to their surroundings".
-* Before you use context, try passing props or passing JSX as `children`.
-
 </Recap>
 
 <Challenges>


### PR DESCRIPTION
# context를 사용해 데이터를 깊게 전달하기 번역 및 불필요한 영문 제거

다음 페이지를 번역하였습니다.
또한, 이미 번역되었음에도 계속 남아있던 영어 원문을 제거하였습니다.

페이지 링크(https://ko.react.dev/learn/passing-data-deeply-with-context)

## 필수 확인 사항

- [x] [기여자 행동 강령 규약<sup>Code of Conduct</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CODE_OF_CONDUCT.md)
- [x] [기여 가이드라인<sup>Contributing</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md)
- [x] [공통 스타일 가이드<sup>Universal Style Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [번역을 위한 모범 사례<sup>Best Practices for Translation</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [번역 용어 정리<sup>Translate Glossary</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [`textlint` 가이드<sup>Textlint Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint-guide.md)
- [x] [맞춤법 검사<sup>Spelling Check</sup>](https://nara-speller.co.kr/speller/)

## 선택 확인 사항

- [ ] 번역 초안 작성<sup>Draft Translation</sup>
- [ ] 리뷰 반영<sup>Resolve Reviews</sup>
