### PR TITLE
docs: fix typo in removing-effect-dependencies.md

### DIFF
--- a/src/content/learn/removing-effect-dependencies.md
+++ b/src/content/learn/removing-effect-dependencies.md
@@ -509,7 +509,7 @@ function ShippingForm({ country }) {
 1. `country` props를 기반으로 `cities` State를 네트워크에 동기화하려고 합니다.
 2. `city` State를 기반으로 `areas` State를 네트워크에 동기화하려고 합니다.
 
-로직을 두 개의 Effect로 분할하고, 각 Effect는 동기화해야 하는 props즈에 반응합니다.
+로직을 두 개의 Effect로 분할하고, 각 Effect는 동기화해야 하는 props에 반응합니다.
 
 
 ```js {19-33}


### PR DESCRIPTION
# fix typo in removing-effect-dependencies.md

오타가 있어서 수정했습니다.

**수정 전:**
> 로직을 두 개의 Effect로 분할하고, 각 Effect는 동기화해야 하는 props즈에 반응합니다.

**수정 후:**
> 로직을 두 개의 Effect로 분할하고, 각 Effect는 동기화해야 하는 props에 반응합니다.


## 필수 확인 사항

- [x] [기여자 행동 강령 규약<sup>Code of Conduct</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CODE_OF_CONDUCT.md)
- [x] [기여 가이드라인<sup>Contributing</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md)
- [x] [공통 스타일 가이드<sup>Universal Style Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [번역을 위한 모범 사례<sup>Best Practices for Translation</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [번역 용어 정리<sup>Translate Glossary</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [`textlint` 가이드<sup>Textlint Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint-guide.md)
- [x] [맞춤법 검사<sup>Spelling Check</sup>](https://nara-speller.co.kr/speller/)

## 선택 확인 사항

- [ ] 번역 초안 작성<sup>Draft Translation</sup>
- [ ] 리뷰 반영<sup>Resolve Reviews</sup>
