### PR TITLE
docs: remove duplicated English content and improve translation clarity in useActionState docs

### DIFF
--- a/src/content/reference/react/useActionState.md
+++ b/src/content/reference/react/useActionState.md
@@ -68,7 +68,7 @@ function StatefulForm({}) {
 `useActionState`는 다음 세 가지 값을 담은 배열을 반환합니다.
 
 1. 현재 State입니다. 첫 렌더링 시에는 `initialState`와 일치하며, 액션이 실행된 후에는 해당 액션이 반환한 값과 일치합니다.
-2. `<form>` 컴포넌트의 `action` Prop이나, 폼 내부 `<button>` 컴포넌트의 `formAction` Prop에 전달할 수 있는 새 액션입니다. 이 액션은 [startTransition](/reference/react/startTransition) 내에서 수동으로 호출할 수도 있습니다.
+2. `form` 컴포넌트의 `action` Prop이나, 폼 내부 `button` 컴포넌트의 `formAction` Prop에 전달할 수 있는 새 액션입니다. 이 액션은 [`startTransition`](/reference/react/startTransition) 내에서 수동으로 호출할 수도 있습니다.
 3. 현재 Transition이 대기 중인지 알려주는 `isPending` 플래그입니다.
 
 

--- a/src/content/reference/react/useActionState.md
+++ b/src/content/reference/react/useActionState.md
@@ -67,9 +67,10 @@ function StatefulForm({}) {
 
 `useActionState`는 다음 세 가지 값을 담은 배열을 반환합니다.
 
-1. 현재 State입니다. 첫 렌더링 시에는 `initialState`와 일치하며, 액션이 실행된 후에는 액션이 반환한 값과 일치합니다.
-2. `<form>` 컴포넌트의 `action` Prop이나 폼 내부 `<button>` 컴포넌트의 `formAction` Prop에 전달할 수 있는 새 액션입니다.
-3. 폼 액션이 대기 중인지 여부를 알려주는 `isPending` 플래그입니다.
+1. 현재 State입니다. 첫 렌더링 시에는 `initialState`와 일치하며, 액션이 실행된 후에는 해당 액션이 반환한 값과 일치합니다.
+2. `<form>` 컴포넌트의 `action` Prop이나, 폼 내부 `<button>` 컴포넌트의 `formAction` Prop에 전달할 수 있는 새 액션입니다. 이 액션은 [startTransition](/reference/react/startTransition) 내에서 수동으로 호출할 수도 있습니다.
+3. 현재 Transition이 대기 중인지 알려주는 `isPending` 플래그입니다.
+
 
 #### 주의 사항 {/*caveats*/}
 

--- a/src/content/reference/react/useActionState.md
+++ b/src/content/reference/react/useActionState.md
@@ -71,10 +71,6 @@ function StatefulForm({}) {
 2. `<form>` 컴포넌트의 `action` Prop이나 폼 내부 `<button>` 컴포넌트의 `formAction` Prop에 전달할 수 있는 새 액션입니다.
 3. 폼 액션이 대기 중인지 여부를 알려주는 `isPending` 플래그입니다.
 
-1. The current state. During the first render, it will match the `initialState` you have passed. After the action is invoked, it will match the value returned by the action.
-2. A new action that you can pass as the `action` prop to your `form` component or `formAction` prop to any `button` component within the form. The action can also be called manually within [`startTransition`](/reference/react/startTransition).
-3. The `isPending` flag that tells you whether there is a pending Transition.
-
 #### 주의 사항 {/*caveats*/}
 
 * React 서버 컴포넌트를 지원하는 프레임워크에서 `useActionState`를 사용하면, 클라이언트 자바스크립트 실행 전에도 폼과 상호작용할 수 있습니다. 만약 서버 컴포넌트를 사용하지 않는다면, 이는 단순히 컴포넌트 지역 State와 동일하게 동작합니다.


### PR DESCRIPTION
## 변경사항 1

useActionState 섹션의 번역 문서에서 중복된 영어 원문(항목 4~6) 을 제거했습니다.

항목 1, 2, 3에서 이미 한국어로 번역된 설명이 충분히 제공되고 있음에도 불구하고, 바로 아래에 영어 원문(항목 4, 5, 6)이 다시 나열되어 있어 독자의 혼란을 유발할 수 있습니다.

해당 중복 내용은 문서의 가독성을 떨어뜨리고, 다른 번역 문서들과 스타일의 일관성도 맞지 않습니다.

React 공식 문서의 번역 지침에서도 중복 없이 자연스러운 번역 제공을 권장하고 있습니다.

![image](https://github.com/user-attachments/assets/14f72c36-eb5b-489e-9860-8ac3b46f4dea)
- React 공식 문서 useActionState 섹션 PR 부분

따라서, 해당 내용 수정을 통해 문서의 명료성을 향상 시키고 독자의 혼란을 방지하여 전체 번역 문서의 스타일 및 품질 개선을 기대합니다.

## 변경사항 2

`useActionState` 훅에 대한 번역을 최신 영어 원문에 맞춰 업데이트하고, 표현을 보다 자연스럽고 명확하게 다듬었습니다.

기존 번역은 기본적인 의미 전달에는 문제가 없었지만, 일부 문장이 다소 부자연스럽고 기술적인 뉘앙스가 정확하지 않은 부분이 있었습니다.

또한, 최신 React 공식 문서 영문 내용을 기준으로 정확한 의미 전달과 문체 개선이 필요하다고 판단하여 수정했습니다.

![image](https://github.com/user-attachments/assets/02d112ef-2450-4432-8c9a-873e6f27636f)
[React 영문 docs](https://react.dev/reference/react/useActionState)

감사합니다.

## 필수 확인 사항

- [x] [기여자 행동 강령 규약<sup>Code of Conduct</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CODE_OF_CONDUCT.md)
- [x] [기여 가이드라인<sup>Contributing</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md)
- [x] [공통 스타일 가이드<sup>Universal Style Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [번역을 위한 모범 사례<sup>Best Practices for Translation</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [번역 용어 정리<sup>Translate Glossary</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [`textlint` 가이드<sup>Textlint Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint-guide.md)
- [x] [맞춤법 검사<sup>Spelling Check</sup>](https://nara-speller.co.kr/speller/)

## 선택 확인 사항

- [ ] 번역 초안 작성<sup>Draft Translation</sup>
- [ ] 리뷰 반영<sup>Resolve Reviews</sup>
