### PR TITLE
docs: improve and complete Korean translation of useActionState documentation

### DIFF
--- a/src/content/reference/react/useActionState.md
+++ b/src/content/reference/react/useActionState.md
@@ -105,16 +105,16 @@ function MyComponent() {
 
 `useActionState`가 반환하는 배열은 다음과 같은 요소를 갖습니다.
 
-1. 폼의 <CodeStep step={1}>현재 State</CodeStep>입니다. 처음에는 전달한 <CodeStep step={4}>초기 State</CodeStep>로 설정되며, 폼이 제출된 후에는 전달한 <CodeStep step={3}>액션</CodeStep>의 반환값으로 설정됩니다.
-2. `<form>`의 `action` Prop에 전달할 <CodeStep step={2}>새로운 액션</CodeStep>입니다.
+1. 폼의 <CodeStep step={1}>현재 State</CodeStep>는, 처음에는 전달한 <CodeStep step={4}>초기 State</CodeStep>로 설정되며, 폼이 제출된 후에는 전달한 <CodeStep step={3}>액션</CodeStep>의 반환값으로 설정됩니다.
+2. `<form>`의 `action` Prop에 전달하거나 `startTransition` 안에서 직접 호출할 수 있는<CodeStep step={2}>새로운 액션</CodeStep>입니다.
 3. 액션이 처리되는 동안 사용할 수 있는 <CodeStep step={1}>대기<sup>Pending</sup> State</CodeStep>입니다.
-1. The <CodeStep step={1}>current state</CodeStep> of the form, which is initially set to the <CodeStep step={4}>initial state</CodeStep> you provided, and after the form is submitted is set to the return value of the <CodeStep step={3}>action</CodeStep> you provided.
-2. A <CodeStep step={2}>new action</CodeStep> that you pass to `<form>` as its `action` prop or call manually within `startTransition`.
-3. A <CodeStep step={1}>pending state</CodeStep> that you can utilise while your action is processing.
 
-폼 제출 시, <CodeStep step={3}>액션</CodeStep> 함수가 호출되고 그 반환값이 폼의 새로운 <CodeStep step={1}>현재 State</CodeStep>가 됩니다.
 
-또한 <CodeStep step={3}>액션</CodeStep> 함수는 새롭게 추가된 첫 번째 인수로 폼의 <CodeStep step={1}>현재 State</CodeStep>를 받습니다. (처음엔 <CodeStep step={4}>초기 State</CodeStep>, 그 후에는 직전 반환값) 나머지 인수들은 일반 폼 액션 호출과 동일합니다.
+폼이 제출되면, 제공한 <CodeStep step={3}>액션</CodeStep> 함수가 호출되며, 해당 함수의 반환값이 새로운 <CodeStep step={1}>현재 State</CodeStep>로 설정됩니다.
+
+이 <CodeStep step={3}>액션</CodeStep> 함수는 첫 번째 인수로 <CodeStep step={1}>현재 State</CodeStep>를 추가로 전달받습니다.
+처음 제출될 때는<CodeStep step={4}>초기 State</CodeStep>가 전달되며, 이후 제출부터는 직전 호출 시 반환된 값이 전달됩니다. 나머지 인수들은 useActionState를 사용하지 않았을 때와 동일합니다.
+
 
 ```js [[3, 1, "action"], [1, 1, "currentState"]]
 function action(currentState, formData) {


### PR DESCRIPTION
## 변경 내용

- 한국어 번역 내용 아래 혼란이 되는 영어 원문 (항목 4, 5, 6) 삭제
- `useActionState` 관련 문서의 기존 번역을 원문에 더 충실하게 다듬었습니다.
- 함수 시그니처, 상태 흐름, 액션 함수의 인자 전달 방식 등을 보다 명확하고 자연스럽게 표현했습니다.
- 반복적 표현을 줄이고, 문서 스타일에 맞게 문장을 정돈했습니다.
- React 영문 공식 문서의 내용에서 빠진 내용들을 모두 번역하였습니다.

## 변경 배경

- 항목 1, 2, 3에서 이미 한국어로 번역된 설명이 충분히 제공되고 있음에도 불구하고, 바로 아래에 영어 원문(항목 4, 5, 6)이 다시 나열되어 있어 독자의 혼란을 유발할 수 있습니다. 
- 기존 번역은 의미 전달은 되고 있었으나, 문장 구조가 원문과 다소 괴리되어 있거나 축약 표현으로 인해 글을 읽을 때 오해의 소지가 있었습니다.  따라서 초심자나 번역만 보고 학습하는 독자를 고려해 더 직관적이고 정확하게 전달되도록 개선했습니다.
- React 공식 문서와 비교했을 때 빠진 내용들이 있었습니다. 따라서, 빠진 내용들도 번역을 하여 모두 내용에 담았습니다.


![image](https://github.com/user-attachments/assets/2d02f976-d38d-4026-90bc-8b2811f391c5)
- [React 영문 문서](https://react.dev/reference/react/useActionState)

![image](https://github.com/user-attachments/assets/eb73e63d-f9c1-4704-95dc-fb6088b5cdea)
- [현재 React 한글 문서](https://ko.react.dev/reference/react/useActionState#usage)


## 필수 확인 사항

- [x] [기여자 행동 강령 규약<sup>Code of Conduct</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CODE_OF_CONDUCT.md)
- [x] [기여 가이드라인<sup>Contributing</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md)
- [x] [공통 스타일 가이드<sup>Universal Style Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [번역을 위한 모범 사례<sup>Best Practices for Translation</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [번역 용어 정리<sup>Translate Glossary</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [`textlint` 가이드<sup>Textlint Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint-guide.md)
- [x] [맞춤법 검사<sup>Spelling Check</sup>](https://nara-speller.co.kr/speller/)

## 선택 확인 사항

- [ ] 번역 초안 작성<sup>Draft Translation</sup>
- [ ] 리뷰 반영<sup>Resolve Reviews</sup>
