### PR TITLE
docs: fix markdown syntax typo in you-might-not-need-an-effect.md

### DIFF
--- a/src/content/learn/you-might-not-need-an-effect.md
+++ b/src/content/learn/you-might-not-need-an-effect.md
@@ -335,7 +335,7 @@ function Form() {
 
 앞의 예와 동일한 기준을 적용해 보겠습니다.
 
-analytics POST 요청은 Effect에 남아 있어야 합니다. analytics 이벤트를 전송하는 _이유_는 폼이 표시되었기 때문입니다. (개발 중에는 두 번 실행되지만 이를 처리하는 방법은 [여기](/learn/synchronizing-with-effects#sending-analytics)를 참조하세요.)
+analytics POST 요청은 Effect에 남아 있어야 합니다. analytics 이벤트를 전송하는 _이유_ 는 폼이 표시되었기 때문입니다. (개발 중에는 두 번 실행되지만 이를 처리하는 방법은 [여기](/learn/synchronizing-with-effects#sending-analytics)를 참조하세요.)
 
 그러나 `/api/register` POST 요청은 _표시되는_ 폼으로 인해 발생하는 것이 아닙니다. 사용자가 버튼을 누를 때라는 특정 시점에만 요청을 보내려고 합니다. 이 요청은 해당 _특정 상호작용에서만_ 발생해야 합니다. 두 번째 Effect를 삭제하고 해당 POST 요청을 이벤트 핸들러로 이동합니다:
 

--- a/src/content/learn/you-might-not-need-an-effect.md
+++ b/src/content/learn/you-might-not-need-an-effect.md
@@ -335,7 +335,7 @@ function Form() {
 
 앞의 예와 동일한 기준을 적용해 보겠습니다.
 
-analytics POST 요청은 Effect에 남아 있어야 합니다. analytics 이벤트를 전송하는 _이유_ 는 폼이 표시되었기 때문입니다. (개발 중에는 두 번 실행되지만 이를 처리하는 방법은 [여기](/learn/synchronizing-with-effects#sending-analytics)를 참조하세요.)
+analytics POST 요청은 Effect에 남아 있어야 합니다. analytics 이벤트를 전송하는 <em>이유</em>는 폼이 표시되었기 때문입니다. (개발 중에는 두 번 실행되지만 이를 처리하는 방법은 [여기](/learn/synchronizing-with-effects#sending-analytics)를 참조하세요.)
 
 그러나 `/api/register` POST 요청은 _표시되는_ 폼으로 인해 발생하는 것이 아닙니다. 사용자가 버튼을 누를 때라는 특정 시점에만 요청을 보내려고 합니다. 이 요청은 해당 _특정 상호작용에서만_ 발생해야 합니다. 두 번째 Effect를 삭제하고 해당 POST 요청을 이벤트 핸들러로 이동합니다:
 


### PR DESCRIPTION
<!--
  PR을 보내주셔서 감사합니다! 여러분과 같은 기여자들이 React를 더욱 멋지게 만듭니다!

  기존 이슈와 관련된 PR이라면, 아래에 이슈 번호를 추가해주세요.
-->

# `you-might-not-need-an-effect.md` 문서에서 마크다운 문법 오류 수정

<!--
  어떤 종류의 PR인지 상세 내용을 작성해주세요.
-->

아래 문단을 보면 `_이유_는` 이라고 적힌 부분이 있는데 이는 렌더링 되어 보여질 때 `<em>이유</em>는` 으로 보여지는 것이 아닌, `_이유_는` 처럼 렌더링 되어 보여집니다.

![image](https://github.com/user-attachments/assets/3e0bb636-acdc-46f5-b29a-1bfc43630c14)

https://github.com/reactjs/ko.react.dev/blob/cf4724852a111dd33d92858591b5805cdc25d2e5/src/content/learn/you-might-not-need-an-effect.md?plain=1#L338

이는 CommonMark 스펙을 보았을 때 이어지는 단어 중간에 들어가는 경우 `*`을 사용해야만 강조가 적용되도록 제한되어 있는 것으로 보였습니다, <https://spec.commonmark.org/0.31.2/#emphasis-and-strong-emphasis>:

    Many implementations have also restricted intraword emphasis to the * forms, to avoid unwanted emphasis in words containing internal underscores. (It is best practice to put these in code spans, but users often do not.)

그래서 `*이유*는` 꼴로 변경하는 것도 고려했으나 1) 개인적인 느낌에서 한글을 기울여 쓸 경우 옆 단어를 침범하여 보기 좋지 않다는 느낌이 있고[^1], 2) 다른 부분에서 의도적으로 띄어쓰는 방향으로 작성한 것으로 보이는 부분이 있어 `_이유_ 는` 꼴로 바꾸는 PR을 만들어 올립니다.

https://github.com/reactjs/ko.react.dev/blob/cf4724852a111dd33d92858591b5805cdc25d2e5/src/content/learn/lifecycle-of-reactive-effects.md?plain=1#L77

혹시 관련하여 이미 논의 및 결정된 사항이 있다면 공유주시면 참고해서 수정하겠습니다 🙏🏻 

[^1]: 관련하여 찾아봤던 논의를 첨부드립니다, https://github.com/mdn/translated-content/issues/1537

## 필수 확인 사항

- [x] [기여자 행동 강령 규약<sup>Code of Conduct</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CODE_OF_CONDUCT.md)
- [x] [기여 가이드라인<sup>Contributing</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md)
- [x] [공통 스타일 가이드<sup>Universal Style Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [번역을 위한 모범 사례<sup>Best Practices for Translation</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [번역 용어 정리<sup>Translate Glossary</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [`textlint` 가이드<sup>Textlint Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint-guide.md)
- [x] [맞춤법 검사<sup>Spelling Check</sup>](https://nara-speller.co.kr/speller/)

## 선택 확인 사항

- [ ] 번역 초안 작성<sup>Draft Translation</sup>
- [ ] 리뷰 반영<sup>Resolve Reviews</sup>
