### PR TITLE
docs: fix typo in referencing-values-with-refs.md

### DIFF
--- a/src/content/learn/referencing-values-with-refs.md
+++ b/src/content/learn/referencing-values-with-refs.md
@@ -616,7 +616,7 @@ export default function Chat() {
 
 <Solution>
 
-state는 [snapshot 처럼](/learn/state-as-a-snapshot) 작동하므로 타임아웃과 같은 비동기 작업에서 최신 state를 읽을 수 없습니다. 그러나 최신 입력 텍스트를 ref에 유지할 수 있습니다. ref는 변경할 수 있으므로 언제든지 `current` 프로퍼티를 읽을 수 있습니다. current 텍스트는 렌더링에도 사용되므로, 이 예에서는 state 변수(렌더링을 위한) *둘 다*와 ref(시간 초과 시 읽음)가 필요합니다. current ref를 수동으로 업데이트해야 합니다.
+state는 [snapshot 처럼](/learn/state-as-a-snapshot) 작동하므로 타임아웃과 같은 비동기 작업에서 최신 state를 읽을 수 없습니다. 그러나 최신 입력 텍스트를 ref에 유지할 수 있습니다. ref는 변경할 수 있으므로 언제든지 `current` 프로퍼티를 읽을 수 있습니다. current 텍스트는 렌더링에도 사용되므로, 이 예에서는 state 변수(렌더링을 위한)와 ref(시간 초과 시 읽음) *둘 다* 필요합니다. current ref를 수동으로 업데이트해야 합니다.
 
 <Sandpack>
 


### PR DESCRIPTION
# 문장의 의미 불일치 수정

'챌린지 4 of 4: 최신 state 읽기' 中 정답보기 클릭 시 보이는 해설이 원문과 일치하지 않는 부분이 있어 수정했습니다.

```md
- current 텍스트는 렌더링에도 사용되므로, 이 예에서는 state 변수(렌더링을 위한) 둘 다와 ref(시간 초과 시 읽음)가 필요합니다.
+ current 텍스트는 렌더링에도 사용되므로, 이 예에서는 state 변수(렌더링을 위한)와 ref(시간 초과 시 읽음) 둘 다 필요합니다.
```

* 원문
https://react.dev/learn/referencing-values-with-refs#challenges

* 번역
https://ko.react.dev/learn/referencing-values-with-refs#challenges

## 필수 확인 사항

- [x] [기여자 행동 강령 규약<sup>Code of Conduct</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CODE_OF_CONDUCT.md)
- [x] [기여 가이드라인<sup>Contributing</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md)
- [x] [공통 스타일 가이드<sup>Universal Style Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [번역을 위한 모범 사례<sup>Best Practices for Translation</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [번역 용어 정리<sup>Translate Glossary</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [`textlint` 가이드<sup>Textlint Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint-guide.md)
- [x] [맞춤법 검사<sup>Spelling Check</sup>](https://nara-speller.co.kr/speller/)

## 선택 확인 사항

- [ ] 번역 초안 작성<sup>Draft Translation</sup>
- [ ] 리뷰 반영<sup>Resolve Reviews</sup>
