### PR TITLE
docs: improve sentences for more natural phrasing

### DIFF
--- a/src/content/learn/referencing-values-with-refs.md
+++ b/src/content/learn/referencing-values-with-refs.md
@@ -248,7 +248,7 @@ function useRef(initialValue) {
 }
 ```
 
-첫 번째 렌더링 중에 `useRef`는 `{ current: initialValue }`을 반환합니다. 이 객체는 React에 의해 저장되므로 다음 렌더링 중에 같은 객체가 반환됩니다. 이 예시에서는 State Setter를 사용하지 않는 점에 주목하세요. `useRef`는 항상 동일한 객체를 반환해야 하므로 필요하지 않습니다!
+첫 번째 렌더링 중에 `useRef`는 `{ current: initialValue }`를 반환합니다. 이 객체는 React에 의해 저장되므로 다음 렌더링 중에 같은 객체를 반환합니다. 이 예시에서는 State Setter를 사용하지 않는 점에 주목하세요. `useRef`는 항상 동일한 객체를 반환해야 하므로 필요하지 않습니다!
 
 React는 `useRef`가 실제로 충분히 일반적이기 때문에 built-in 버전을 제공합니다. setter가 없는 일반적인 state 변수라고 생각할 수 있습니다. 객체 지향 프로그래밍에 익숙하다면 Ref는 인스턴스 필드를 상기시킬 수 있습니다. 하지만 `this.something` 대신에 `somethingRef.current` 처럼 써야합니다.
 

--- a/src/content/learn/referencing-values-with-refs.md
+++ b/src/content/learn/referencing-values-with-refs.md
@@ -248,7 +248,7 @@ function useRef(initialValue) {
 }
 ```
 
-첫 번째 렌더링 중에 `useRef`는 `{ current: initialValue }`을 반환합니다. 이 객체는 React에 의해 저장되므로 다음 렌더링 중에 같은 객체가 반환됩니다. 이 예시에서는 State Setter가 어떻게 사용되지 않는지 주의하세요. `useRef`는 항상 동일한 객체를 반환해야 하므로 필요하지 않습니다!
+첫 번째 렌더링 중에 `useRef`는 `{ current: initialValue }`을 반환합니다. 이 객체는 React에 의해 저장되므로 다음 렌더링 중에 같은 객체가 반환됩니다. 이 예시에서는 State Setter를 사용하지 않는 점에 주목하세요. `useRef`는 항상 동일한 객체를 반환해야 하므로 필요하지 않습니다!
 
 React는 `useRef`가 실제로 충분히 일반적이기 때문에 built-in 버전을 제공합니다. setter가 없는 일반적인 state 변수라고 생각할 수 있습니다. 객체 지향 프로그래밍에 익숙하다면 Ref는 인스턴스 필드를 상기시킬 수 있습니다. 하지만 `this.something` 대신에 `somethingRef.current` 처럼 써야합니다.
 


### PR DESCRIPTION
# 어색하게 직역된 문장 의역

[Ref와 State의 차이#자세히 살펴보기: useRef는 내부적으로 어떻게 동작하나요?](https://ko.react.dev/learn/referencing-values-with-refs#differences-between-refs-and-state) 부분을 아래와 같이 수정했습니다. 이때, 독자 입장에서 더 읽기 편하게 하는 데 중점을 두었습니다.

```
- 이 예시에서는 State Setter가 어떻게 사용되지 않는지 주의하세요.
+ 이 예시에서는 State Setter를 사용하지 않는 점에 주목하세요.
```

[원문](https://react.dev/learn/referencing-values-with-refs#differences-between-refs-and-state)에는 'Note how the state setter is unused in this example.'라고 표현합니다. 코드와 설명의 앞뒤 맥락을 보면, 'useRef는 항상 동일한 객체를 반환해야 하므로 state setter가 필요하지 않다.'라는 것을 전달하려는 목적으로 보입니다. 따라서 'how'를 '어떻게'로 직역하는 대신, state setter를 사용하지 않는 '현상' 자체에 대한 뉘앙스가 담기게 의역해보았습니다. 더불어, 이런 뉘앙스에는 '주의'보다는 '주목'이 의미 전달에 더 적합하다고 판단했습니다. (* [note 뜻 - 네이버 사전](https://en.dict.naver.com/#/entry/enko/775deb835c894f519a6912a545c24f64))


## 필수 확인 사항

- [x] [기여자 행동 강령 규약<sup>Code of Conduct</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CODE_OF_CONDUCT.md)
- [x] [기여 가이드라인<sup>Contributing</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md)
- [x] [공통 스타일 가이드<sup>Universal Style Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [번역을 위한 모범 사례<sup>Best Practices for Translation</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [번역 용어 정리<sup>Translate Glossary</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [`textlint` 가이드<sup>Textlint Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint-guide.md)
- [x] [맞춤법 검사<sup>Spelling Check</sup>](https://nara-speller.co.kr/speller/)

## 선택 확인 사항

- [ ] 번역 초안 작성<sup>Draft Translation</sup>
- [ ] 리뷰 반영<sup>Resolve Reviews</sup>
