### PR TITLE
docs: add a missing translation

### DIFF
--- a/src/content/learn/manipulating-the-dom-with-refs.md
+++ b/src/content/learn/manipulating-the-dom-with-refs.md
@@ -1059,7 +1059,7 @@ img {
 
 <Hint>
 
-`SearchInput` 같은 컴포넌트에서 DOM 노드를 노출하려면 `ref`를 prop 처럼 전달해야 합니다.
+`SearchInput` 같은 컴포넌트에서 DOM 노드를 노출하려면 `ref`를 Prop처럼 전달해야 합니다.
 
 </Hint>
 

--- a/src/content/learn/manipulating-the-dom-with-refs.md
+++ b/src/content/learn/manipulating-the-dom-with-refs.md
@@ -1059,9 +1059,7 @@ img {
 
 <Hint>
 
-`SearchInput`같은 컴포넌트에서 `forwardRef`를 사용해서 DOM 노드를 노출할 필요가 있습니다.
-
-You'll need to pass `ref` as a prop to opt into exposing a DOM node from your own component like `SearchInput`.
+`SearchInput` 같은 컴포넌트에서 DOM 노드를 노출하려면 `ref`를 prop 처럼 전달해야 합니다.
 
 </Hint>
 


### PR DESCRIPTION
# 누락된 번역 추가

'Ref로 DOM 조작하기' 페이지의 [챌린지 4 of 4: 별개의 컴포넌트에서 검색 필드에 포커스 이동하기](https://ko.react.dev/learn/manipulating-the-dom-with-refs#challenges) 내 '힌트 보기' 클릭 시 표시되는 설명을 수정했습니다. 해당 부분에 오래된 설명(한국어)과 원문의 최신 설명(영어)이 공존하는 것으로 보입니다. 
※ [React 19 버전 이후, forwardRef는 deprecated됨](https://ko.react.dev/reference/react/forwardRef)

오래된 설명(한국어)을 제외하고 원문의 최신 설명(영어)을 적절히 번역하여, 다음과 같이 수정할 것을 제안합니다.

```
- `SearchInput`같은 컴포넌트에서 `forwardRef`를 사용해서 DOM 노드를 노출할 필요가 있습니다.
+ `SearchInput` 같은 컴포넌트에서 DOM 노드를 노출하려면 `ref`를 prop 처럼 전달해야 합니다.
```

## 필수 확인 사항

- [x] [기여자 행동 강령 규약<sup>Code of Conduct</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CODE_OF_CONDUCT.md)
- [x] [기여 가이드라인<sup>Contributing</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md)
- [x] [공통 스타일 가이드<sup>Universal Style Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [번역을 위한 모범 사례<sup>Best Practices for Translation</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [번역 용어 정리<sup>Translate Glossary</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [`textlint` 가이드<sup>Textlint Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint-guide.md)
- [x] [맞춤법 검사<sup>Spelling Check</sup>](https://nara-speller.co.kr/speller/)

## 선택 확인 사항

- [ ] 번역 초안 작성<sup>Draft Translation</sup>
- [ ] 리뷰 반영<sup>Resolve Reviews</sup>
