### PR TITLE
docs: Translate remaining English sentences in useId.md and useLayoutEffect.md to Korean

### DIFF
--- a/src/content/reference/react/useId.md
+++ b/src/content/reference/react/useId.md
@@ -46,7 +46,7 @@ function PasswordField() {
 
 * `useId`를 리스트의 **key를 생성하기 위해 사용하면 안 됩니다**. [Key는 데이터로부터 생성해야 합니다.](/learn/rendering-lists#where-to-get-your-key)
 
-* `useId` currently cannot be used in [async Server Components](/reference/rsc/server-components#async-components-with-server-components).
+* `useId`는 현재 [비동기 서버 컴포넌트](/reference/rsc/server-components#async-components-with-server-components)에서 사용할 수 없습니다.
 
 ---
 
@@ -333,4 +333,4 @@ const root = hydrateRoot(
 );
 ```
 
-You do not need to pass `identifierPrefix` if you only have one React app on the page.
+페이지에 React 앱이 하나만 있는 경우에는 `identifierPrefix`를 전달할 필요가 없습니다.

--- a/src/content/reference/react/useLayoutEffect.md
+++ b/src/content/reference/react/useLayoutEffect.md
@@ -68,7 +68,7 @@ function Tooltip() {
 
 *  `useLayoutEffect` 내부의 코드와 이로 인한 모든 state 업데이트는 **브라우저가 화면을 다시 그리는 것을 막습니다.** 과도하게 사용하면 앱이 느려집니다. 가능하면 [`useEffect`](/reference/react/useEffect)를 사용하세요.
 
-* If you trigger a state update inside `useLayoutEffect`, React will execute all remaining Effects immediately including `useEffect`.
+* `useLayoutEffect` 내부에서 state 업데이트를 실행하면 React는 `useEffect`를 포함한 나머지 모든 Effect를 즉시 실행합니다.
 
 ---
 


### PR DESCRIPTION
<!--
  PR을 보내주셔서 감사합니다! 여러분과 같은 기여자들이 React를 더욱 멋지게 만듭니다!

  기존 이슈와 관련된 PR이라면, 아래에 이슈 번호를 추가해주세요.
-->

# <!-- 제목을 작성해주세요. -->

<!--
  어떤 종류의 PR인지 상세 내용을 작성해주세요.
-->

# 번역: useId.md와 useLayoutEffect.md의 남은 영어 문장들 한국어로 번역

### 변경 사항

두 개의 레퍼런스 문서에서 번역되지 않은 영어 문장들을 한국어로 번역했습니다.

### `src/content/reference/react/useId.md`
- "useId currently cannot be used in async Server Components" 
  → "useId는 현재 비동기 서버 컴포넌트에서 사용할 수 없습니다"
- "You do not need to pass identifierPrefix if you only have one React app on the page" 
  → "페이지에 React 앱이 하나만 있는 경우에는 identifierPrefix를 전달할 필요가 없습니다"

### `src/content/reference/react/useLayoutEffect.md`
- "If you trigger a state update inside useLayoutEffect, React will execute all remaining Effects immediately including useEffect" 
  → "useLayoutEffect 내부에서 state 업데이트를 실행하면 React는 useEffect를 포함한 나머지 모든 Effect를 즉시 실행합니다"


## 필수 확인 사항

- [x] [기여자 행동 강령 규약<sup>Code of Conduct</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CODE_OF_CONDUCT.md)
- [x] [기여 가이드라인<sup>Contributing</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md)
- [x] [공통 스타일 가이드<sup>Universal Style Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [번역을 위한 모범 사례<sup>Best Practices for Translation</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [번역 용어 정리<sup>Translate Glossary</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [`textlint` 가이드<sup>Textlint Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint-guide.md)
- [x] [맞춤법 검사<sup>Spelling Check</sup>](https://nara-speller.co.kr/speller/)

## 선택 확인 사항

- [ ] 번역 초안 작성<sup>Draft Translation</sup>
- [ ] 리뷰 반영<sup>Resolve Reviews</sup>
