### PR TITLE
docs: translate missing ref callback line in Strict Mode section

### DIFF
--- a/src/content/reference/react/StrictMode.md
+++ b/src/content/reference/react/StrictMode.md
@@ -44,7 +44,7 @@ Strict Mode는 다음과 같은 개발 전용 동작을 활성화합니다.
 
 - 컴포넌트가 순수하지 않은 렌더링으로 인한 버그를 찾기 위해 [추가로 다시 렌더링합니다.](#fixing-bugs-found-by-double-rendering-in-development)
 - 컴포넌트가 Effect 클린업이 누락되어 발생한 버그를 찾기 위해 [Effect를 다시 실행합니다.](#fixing-bugs-found-by-re-running-effects-in-development)
-- Your components will [re-run refs callbacks an extra time](#fixing-bugs-found-by-re-running-ref-callbacks-in-development) to find bugs caused by missing ref cleanup.
+- 컴포넌트가 ref 클린업이 누락되어 발생한 버그를 찾기 위해 [ref를 다시 실행합니다.](#fixing-bugs-found-by-re-running-ref-callbacks-in-development)
 - 컴포넌트가 [더 이상 사용되지 않는 API를 사용하는지 확인합니다.](#fixing-deprecation-warnings-enabled-by-strict-mode)
 
 

--- a/src/content/reference/react/StrictMode.md
+++ b/src/content/reference/react/StrictMode.md
@@ -44,7 +44,7 @@ Strict Mode는 다음과 같은 개발 전용 동작을 활성화합니다.
 
 - 컴포넌트가 순수하지 않은 렌더링으로 인한 버그를 찾기 위해 [추가로 다시 렌더링합니다.](#fixing-bugs-found-by-double-rendering-in-development)
 - 컴포넌트가 Effect 클린업이 누락되어 발생한 버그를 찾기 위해 [Effect를 다시 실행합니다.](#fixing-bugs-found-by-re-running-effects-in-development)
-- 컴포넌트가 ref 클린업이 누락되어 발생한 버그를 찾기 위해 [ref를 다시 실행합니다.](#fixing-bugs-found-by-re-running-ref-callbacks-in-development)
+- 컴포넌트가 Ref 클린업이 누락되어 발생한 버그를 찾기 위해 [Ref 콜백을 다시 실행합니다.](#fixing-bugs-found-by-re-running-ref-callbacks-in-development)
 - 컴포넌트가 [더 이상 사용되지 않는 API를 사용하는지 확인합니다.](#fixing-deprecation-warnings-enabled-by-strict-mode)
 
 


### PR DESCRIPTION
# Strict Mode 섹션 누락된 번역 추가

Strict Mode 개발 전용 동작 설명 부분에서 번역되지 않은 영어 문장을 한국어로 번역했습니다.

**변경된 내용:**
- "Your components will re-run refs callbacks an extra time to find bugs caused by missing ref cleanup."
→ "컴포넌트가 ref 클린업이 누락되어 발생한 버그를 찾기 위해 ref를 다시 실행합니다."

**변경 이유:**
- 해당 항목만 영어로 남아있어 문서의 일관성이 떨어짐
- 다른 항목들과 동일한 번역 스타일로 통일하여 가독성 향상

<img width="916" height="247" alt="스크린샷 2025-07-29 오후 10 03 22" src="https://github.com/user-attachments/assets/592271e9-df67-4087-8547-b9ef085b1784" />

<img width="824" height="268" alt="스크린샷 2025-07-29 오후 10 03 06" src="https://github.com/user-attachments/assets/b305833e-ccfe-474d-ace5-464c1e99ae59" />


## 필수 확인 사항

- [x] [기여자 행동 강령 규약<sup>Code of Conduct</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CODE_OF_CONDUCT.md)
- [x] [기여 가이드라인<sup>Contributing</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md)
- [x] [공통 스타일 가이드<sup>Universal Style Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [번역을 위한 모범 사례<sup>Best Practices for Translation</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [번역 용어 정리<sup>Translate Glossary</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [`textlint` 가이드<sup>Textlint Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint-guide.md)
- [x] [맞춤법 검사<sup>Spelling Check</sup>](https://nara-speller.co.kr/speller/)

## 선택 확인 사항

- [x] 번역 초안 작성<sup>Draft Translation</sup>
- [ ] 리뷰 반영<sup>Resolve Reviews</sup>