### PR TITLE
docs: update content/reference/react/useState.md

### DIFF
--- a/src/content/reference/react/useState.md
+++ b/src/content/reference/react/useState.md
@@ -85,7 +85,7 @@ function handleClick() {
 
 * React는 [state 업데이트를 batch 합니다. ](/learn/queueing-a-series-of-state-updates) **모든 이벤트 핸들러가 실행되고** `set` 함수를 호출한 후에 화면을 업데이트합니다. 이렇게 하면 단일 이벤트 중에 여러 번 리렌더링 하는 것을 방지할 수 있습니다. 드물지만 DOM에 접근하기 위해 React가 화면을 더 일찍 업데이트하도록 강제해야 하는 경우, [`flushSync`](/reference/react-dom/flushSync)를 사용할 수 있습니다.
 
-* `set` 함수는 항상 동일한 식별자를 가지기 때문에 Effect 의존성 목록에서 자주 생략됩니다. 하지만 의존성에 포함하더라도 Effect가 다시 실행되지는 않습니다. 린터가 오류 없이 생략을 허용한다면, 그대로 생략해도 안전합니다. [Effect 의존성 제거 방법에 대해 더 알아보기](/learn/removing-effect-dependencies#move-dynamic-objects-and-functions-inside-your-effect)
+* `set` 함수는 항상 동일한 식별자를 가지기 때문에 Effect 의존성 목록에서 자주 생략됩니다. 하지만 의존성에 포함하더라도 Effect가 다시 실행되지는 않습니다. 린터가 오류 없이 생략을 허용한다면, 그대로 생략해도 안전합니다. [Effect 의존성 제거 방법에 대해 더 알아보세요](/learn/removing-effect-dependencies#move-dynamic-objects-and-functions-inside-your-effect).
 
 * *렌더링 도중* `set` 함수를 호출하는 것은 현재 렌더링 중인 컴포넌트 내에서만 허용됩니다. React는 해당 출력을 버리고 즉시 새로운 state로 다시 렌더링을 시도합니다. 이 패턴은 거의 필요하지 않지만 **이전 렌더링의 정보를 저장하는 데 사용할 수 있습니다**. [아래 예시를 참고하세요.](#storing-information-from-previous-renders)
 

--- a/src/content/reference/react/useState.md
+++ b/src/content/reference/react/useState.md
@@ -85,7 +85,7 @@ function handleClick() {
 
 * React는 [state 업데이트를 batch 합니다. ](/learn/queueing-a-series-of-state-updates) **모든 이벤트 핸들러가 실행되고** `set` 함수를 호출한 후에 화면을 업데이트합니다. 이렇게 하면 단일 이벤트 중에 여러 번 리렌더링 하는 것을 방지할 수 있습니다. 드물지만 DOM에 접근하기 위해 React가 화면을 더 일찍 업데이트하도록 강제해야 하는 경우, [`flushSync`](/reference/react-dom/flushSync)를 사용할 수 있습니다.
 
-* `set` 함수는 안정적인 식별자를 가지므로, 종종 Effect 의존성 목록에서 생략되는 것을 볼 수 있습니다. 하지만 이를 포함하더라도 Effect가 실행되지는 않습니다. 린터가 의존성을 오류 없이 생략하도록 허용한다면, 그렇게 해도 안전합니다. [Effect 의존성 제거에 대해 더 알아보려면 관련 문서를 참고하세요.](/learn/removing-effect-dependencies#move-dynamic-objects-and-functions-inside-your-effect)
+* `set` 함수는 항상 동일한 식별자를 가지기 때문에 Effect 의존성 목록에서 자주 생략됩니다. 하지만 의존성에 포함하더라도 Effect가 다시 실행되지는 않습니다. 린터가 오류 없이 생략을 허용한다면, 그대로 생략해도 안전합니다. [Effect 의존성 제거 방법에 대해 더 알아보기](/learn/removing-effect-dependencies#move-dynamic-objects-and-functions-inside-your-effect)
 
 * *렌더링 도중* `set` 함수를 호출하는 것은 현재 렌더링 중인 컴포넌트 내에서만 허용됩니다. React는 해당 출력을 버리고 즉시 새로운 state로 다시 렌더링을 시도합니다. 이 패턴은 거의 필요하지 않지만 **이전 렌더링의 정보를 저장하는 데 사용할 수 있습니다**. [아래 예시를 참고하세요.](#storing-information-from-previous-renders)
 

--- a/src/content/reference/react/useState.md
+++ b/src/content/reference/react/useState.md
@@ -85,7 +85,7 @@ function handleClick() {
 
 * React는 [state 업데이트를 batch 합니다. ](/learn/queueing-a-series-of-state-updates) **모든 이벤트 핸들러가 실행되고** `set` 함수를 호출한 후에 화면을 업데이트합니다. 이렇게 하면 단일 이벤트 중에 여러 번 리렌더링 하는 것을 방지할 수 있습니다. 드물지만 DOM에 접근하기 위해 React가 화면을 더 일찍 업데이트하도록 강제해야 하는 경우, [`flushSync`](/reference/react-dom/flushSync)를 사용할 수 있습니다.
 
-* The `set` function has a stable identity, so you will often see it omitted from Effect dependencies, but including it will not cause the Effect to fire. If the linter lets you omit a dependency without errors, it is safe to do. [Learn more about removing Effect dependencies.](/learn/removing-effect-dependencies#move-dynamic-objects-and-functions-inside-your-effect)
+* `set` 함수는 안정적인 식별자를 가지므로, 종종 Effect 의존성 목록에서 생략되는 것을 볼 수 있습니다. 하지만 이를 포함하더라도 Effect가 실행되지는 않습니다. 린터가 의존성을 오류 없이 생략하도록 허용한다면, 그렇게 해도 안전합니다. [Effect 의존성 제거에 대해 더 알아보려면 관련 문서를 참고하세요.](/learn/removing-effect-dependencies#move-dynamic-objects-and-functions-inside-your-effect)
 
 * *렌더링 도중* `set` 함수를 호출하는 것은 현재 렌더링 중인 컴포넌트 내에서만 허용됩니다. React는 해당 출력을 버리고 즉시 새로운 state로 다시 렌더링을 시도합니다. 이 패턴은 거의 필요하지 않지만 **이전 렌더링의 정보를 저장하는 데 사용할 수 있습니다**. [아래 예시를 참고하세요.](#storing-information-from-previous-renders)
 


### PR DESCRIPTION
# useState 번역

다음 페이지를 번역했습니다.

[useState](https://ko.react.dev/reference/react/useState)

## 필수 확인 사항

- [x] [기여자 행동 강령 규약<sup>Code of Conduct</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CODE_OF_CONDUCT.md)
- [x] [기여 가이드라인<sup>Contributing</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md)
- [x] [공통 스타일 가이드<sup>Universal Style Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [번역을 위한 모범 사례<sup>Best Practices for Translation</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [번역 용어 정리<sup>Translate Glossary</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [`textlint` 가이드<sup>Textlint Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint-guide.md)
- [x] [맞춤법 검사<sup>Spelling Check</sup>](https://nara-speller.co.kr/speller/)

## 선택 확인 사항

- [ ] 번역 초안 작성<sup>Draft Translation</sup>
- [ ] 리뷰 반영<sup>Resolve Reviews</sup>
