### PR TITLE
docs: update Apple OS X references to macOS in text

### DIFF
--- a/src/content/learn/editor-setup.md
+++ b/src/content/learn/editor-setup.md
@@ -23,7 +23,7 @@ title: 에디터 설정하기
 
 * [WebStorm](https://www.jetbrains.com/ko-kr/webstorm/)은 자바스크립트<sup>JavaScript</sup>에 특화되어 설계된 통합 개발 환경입니다.
 * [Sublime Text](https://www.sublimetext.com/)는 JSX와 타입스크립트<sup>TypeScript</sup>를 지원하며 [문법 강조](https://stackoverflow.com/a/70960574/458193) 및 자동 완성 기능이 내장되어 있습니다.
-* [Vim](https://www.vim.org/)은 모든 종류의 텍스트를 매우 효율적으로 생성하고 변경할 수 있도록 설계된 텍스트 편집기입니다. 대부분의 UNIX 시스템과 Apple OS X에 "vi"로 포함되어 있습니다.
+* [Vim](https://www.vim.org/)은 모든 종류의 텍스트를 매우 효율적으로 생성하고 변경할 수 있도록 설계된 텍스트 편집기입니다. 대부분의 UNIX 시스템과 macOS에 "vi"로 포함되어 있습니다.
 
 ## 에디터 기능 추천 {/*recommended-text-editor-features*/}
 


### PR DESCRIPTION
<!--
  PR을 보내주셔서 감사합니다! 여러분과 같은 기여자들이 React를 더욱 멋지게 만듭니다!

  기존 이슈와 관련된 PR이라면, 아래에 이슈 번호를 추가해주세요.
-->

### Apple 운영체제 명칭 수정

Apple 운영체제 명칭이 과거 "Apple OS X"에서 현재 "macOS"로 변경된 부분을 수정했습니다.  
이는 공식 명칭에 맞춘 정확한 표현이며, 문서의 신뢰성을 높입니다.

## 필수 확인 사항

- [x] [기여자 행동 강령 규약](https://github.com/reactjs/ko.react.dev/blob/main/CODE_OF_CONDUCT.md)
- [x] [기여 가이드라인](https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md)
- [x] [공통 스타일 가이드](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [번역을 위한 모범 사례](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [번역 용어 정리](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [textlint 가이드](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint-guide.md)
- [x] [맞춤법 검사](https://nara-speller.co.kr/speller/)

## 선택 확인 사항

- [ ] 번역 초안 작성<sup>Draft Translation</sup>
- [ ] 리뷰 반영<sup>Resolve Reviews</sup>
