### PR TITLE
fix: resolve Sandpack examples not displaying in `Activity` documentation

### DIFF
--- a/src/content/reference/react/Activity.md
+++ b/src/content/reference/react/Activity.md
@@ -150,7 +150,9 @@ export default function TabButton({ action, children, isActive }) {
 ```
 
 ```js src/AboutTab.js hidden
-import {unstable_ViewTransition as ViewTransition} from 'react';
+import {unstable_ViewTransition, ViewTransition as ViewTransitionStable} from 'react';
+
+let ViewTransition = ViewTransitionStable ?? unstable_ViewTransition;
 
 export default function AboutTab() {
   return (
@@ -162,8 +164,10 @@ export default function AboutTab() {
 ```
 
 ```js src/PostsTab.js hidden
-import {use, unstable_ViewTransition as ViewTransition} from 'react';
+import {use, unstable_ViewTransition, ViewTransition as ViewTransitionStable} from 'react';
 import { fetchData } from './data.js';
+
+let ViewTransition = ViewTransitionStable ?? unstable_ViewTransition;
 
 function PostsTab() {
   const posts = use(fetchData('/posts'));
@@ -256,24 +260,6 @@ button { margin-right: 10px }
 b { display: inline-block; margin-right: 10px; }
 .pending { color: #777; }
 ```
-
-```json package.json hidden
-{
-  "dependencies": {
-    "react": "experimental",
-    "react-dom": "experimental",
-    "react-scripts": "latest",
-    "toastify-js": "1.12.0"
-  },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
-  }
-}
-```
-
 </Sandpack>
 
 이 예시에서 "Posts" 탭을 클릭할 때 게시물이 로드될 때까지 기다려야 합니다.
@@ -283,11 +269,13 @@ b { display: inline-block; margin-right: 10px; }
 <Sandpack>
 
 ```js
-import { Suspense, useState, unstable_Activity as Activity } from "react";
+import { Suspense, useState, unstable_Activity, Activity as ActivityStable } from "react";
 import TabButton from "./TabButton.js";
 import AboutTab from "./AboutTab.js";
 import PostsTab from "./PostsTab.js";
 import ContactTab from "./ContactTab.js";
+
+let Activity = ActivityStable ?? unstable_Activity;
 
 export default function TabContainer() {
   const [tab, setTab] = useState("about");
@@ -342,7 +330,9 @@ export default function TabButton({ action, children, isActive }) {
 ```
 
 ```js src/AboutTab.js hidden
-import {unstable_ViewTransition as ViewTransition} from 'react';
+import {unstable_ViewTransition, ViewTransition as ViewTransitionStable} from 'react';
+
+let ViewTransition = ViewTransitionStable ?? unstable_ViewTransition;
 
 export default function AboutTab() {
   return (
@@ -354,8 +344,10 @@ export default function AboutTab() {
 ```
 
 ```js src/PostsTab.js hidden
-import {use, unstable_ViewTransition as ViewTransition} from 'react';
+import {use, unstable_ViewTransition, ViewTransition as ViewTransitionStable} from 'react';
 import { fetchData } from './data.js';
+
+let ViewTransition = ViewTransitionStable ?? unstable_ViewTransition;
 
 function PostsTab() {
   const posts = use(fetchData('/posts'));
@@ -382,7 +374,9 @@ export default PostsTab;
 ```
 
 ```js src/ContactTab.js hidden
-import {unstable_ViewTransition as ViewTransition} from 'react';
+import {unstable_ViewTransition, ViewTransition as ViewTransitionStable} from 'react';
+
+let ViewTransition = ViewTransitionStable ?? unstable_ViewTransition;
 
 export default function ContactTab() {
   return (
@@ -449,22 +443,6 @@ b { display: inline-block; margin-right: 10px; }
 .pending { color: #777; }
 ```
 
-```json package.json hidden
-{
-  "dependencies": {
-    "react": "experimental",
-    "react-dom": "experimental",
-    "react-scripts": "latest",
-    "toastify-js": "1.12.0"
-  },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
-  }
-}
-```
 
 </Sandpack>
 
@@ -553,7 +531,9 @@ export default function TabButton({ action, children, isActive }) {
 ```
 
 ```js src/AboutTab.js hidden
-import {unstable_ViewTransition as ViewTransition} from 'react';
+import {unstable_ViewTransition, ViewTransition as ViewTransitionStable} from 'react';
+
+let ViewTransition = ViewTransitionStable ?? unstable_ViewTransition;
 
 export default function AboutTab() {
   return (
@@ -565,8 +545,10 @@ export default function AboutTab() {
 ```
 
 ```js src/PostsTab.js hidden
-import {use, unstable_ViewTransition as ViewTransition} from 'react';
+import {use, unstable_ViewTransition, ViewTransition as ViewTransitionStable} from 'react';
 import { fetchData } from './data.js';
+
+let ViewTransition = ViewTransitionStable ?? unstable_ViewTransition;
 
 function PostsTab() {
   const posts = use(fetchData('/posts'));
@@ -593,7 +575,9 @@ export default PostsTab;
 ```
 
 ```js src/ContactTab.js hidden
-import {unstable_ViewTransition as ViewTransition} from 'react';
+import {unstable_ViewTransition, ViewTransition as ViewTransitionStable} from 'react';
+
+let ViewTransition = ViewTransitionStable ?? unstable_ViewTransition;
 
 export default function ContactTab() {
   return (
@@ -660,22 +644,6 @@ b { display: inline-block; margin-right: 10px; }
 .pending { color: #777; }
 ```
 
-```json package.json hidden
-{
-  "dependencies": {
-    "react": "experimental",
-    "react-dom": "experimental",
-    "react-scripts": "latest",
-    "toastify-js": "1.12.0"
-  },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
-  }
-}
-```
 
 </Sandpack>
 
@@ -685,11 +653,13 @@ b { display: inline-block; margin-right: 10px; }
 <Sandpack>
 
 ```js
-import { Suspense, useState, unstable_Activity as Activity } from "react";
+import { Suspense, useState, unstable_Activity, Activity as ActivityStable } from "react";
 import TabButton from "./TabButton.js";
 import AboutTab from "./AboutTab.js";
 import PostsTab from "./PostsTab.js";
 import ContactTab from "./ContactTab.js";
+
+let Activity = ActivityStable ?? unstable_Activity;
 
 export default function TabContainer() {
   const [tab, setTab] = useState("about");
@@ -744,7 +714,9 @@ export default function TabButton({ action, children, isActive }) {
 ```
 
 ```js src/AboutTab.js hidden
-import {unstable_ViewTransition as ViewTransition} from 'react';
+import {unstable_ViewTransition, ViewTransition as ViewTransitionStable} from 'react';
+
+let ViewTransition = ViewTransitionStable ?? unstable_ViewTransition;
 
 export default function AboutTab() {
   return (
@@ -756,8 +728,10 @@ export default function AboutTab() {
 ```
 
 ```js src/PostsTab.js hidden
-import {use, unstable_ViewTransition as ViewTransition} from 'react';
+import {use, unstable_ViewTransition, ViewTransition as ViewTransitionStable} from 'react';
 import { fetchData } from './data.js';
+
+let ViewTransition = ViewTransitionStable ?? unstable_ViewTransition;
 
 function PostsTab() {
   const posts = use(fetchData('/posts'));
@@ -784,7 +758,9 @@ export default PostsTab;
 ```
 
 ```js src/ContactTab.js hidden
-import {unstable_ViewTransition as ViewTransition} from 'react';
+import {unstable_ViewTransition, ViewTransition as ViewTransitionStable} from 'react';
+
+let ViewTransition = ViewTransitionStable ?? unstable_ViewTransition;
 
 export default function ContactTab() {
   return (
@@ -851,22 +827,6 @@ b { display: inline-block; margin-right: 10px; }
 .pending { color: #777; }
 ```
 
-```json package.json hidden
-{
-  "dependencies": {
-    "react": "experimental",
-    "react-dom": "experimental",
-    "react-scripts": "latest",
-    "toastify-js": "1.12.0"
-  },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
-  }
-}
-```
 
 </Sandpack>
 
@@ -1053,8 +1013,10 @@ Activity는 처음에 "hidden" 상태로 렌더링할 때 Effect를 생성하지
 <Sandpack>
 
 ```js
-import { useState, useRef, useEffect, unstable_Activity as Activity } from 'react';
+import { useState, useRef, useEffect, unstable_Activity, Activity as ActivityStable } from 'react';
 import VideoChecker from './checker.js';
+
+let Activity = ActivityStable ?? unstable_Activity
 
 function VideoPlayer({ src, isPlaying }) {
   const ref = useRef(null);
@@ -1135,22 +1097,6 @@ b { display: inline-block; margin-right: 10px; }
 video { width: 300px; margin-top: 10px; }
 ```
 
-```json package.json hidden
-{
-  "dependencies": {
-    "react": "experimental",
-    "react-dom": "experimental",
-    "react-scripts": "latest",
-    "toastify-js": "1.12.0"
-  },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
-  }
-}
-```
 
 </Sandpack>
 


### PR DESCRIPTION
# `Activity` 의 예제가 제대로 보이지 않는 이슈 수정


## Problem
- package.json에 `"react": "experimental"` 형태로만 명시되어 react와 react-dom이 서로 다른 해시의 experimental 버전으로 설치됨

## Proposed Changes
- 모든 Sandpack 예제에서 package.json 블록 제거
- experimental 기능 import 시 fallback 패턴 적용하도록 변경

  ```js
  import { unstable_Activity, Activity as ActivityStable } from 'react'; 

  let Activity = ActivityStable ?? unstable_Activity;
  ```

- 영어 문서와 동일한 방식으로 통일

|AS-IS|TO-BE|
|--|--|
|<img width="1222" height="531" alt="image" src="https://github.com/user-attachments/assets/105b9524-5db6-4fb6-82f3-e0d62d2abae0" />|<img width="1208" height="526" alt="image" src="https://github.com/user-attachments/assets/50d56bfa-cdfb-4ea7-9c11-d4cd6a057d10" />|


## 필수 확인 사항

- [x] [기여자 행동 강령 규약<sup>Code of Conduct</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CODE_OF_CONDUCT.md)
- [x] [기여 가이드라인<sup>Contributing</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md)
- [x] [공통 스타일 가이드<sup>Universal Style Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [번역을 위한 모범 사례<sup>Best Practices for Translation</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [번역 용어 정리<sup>Translate Glossary</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [`textlint` 가이드<sup>Textlint Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint-guide.md)
- [x] [맞춤법 검사<sup>Spelling Check</sup>](https://nara-speller.co.kr/speller/)

## 선택 확인 사항

- [ ] 번역 초안 작성<sup>Draft Translation</sup>
- [ ] 리뷰 반영<sup>Resolve Reviews</sup>


refs #1339