### PR TITLE
docs: update stale discord badge in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ko.react.dev
 
-[![React Korea 디스코드 채널](https://dcbadge.vercel.app/api/server/YXdTyCh5KF)](https://discord.gg/YXdTyCh5KF)
+[![React Korea 디스코드 채널](https://img.shields.io/badge/discord-channel?style=for-the-badge&logo=discord&logoSize=100&label=React%20Korea&labelColor=%2323272F&color=%23149ECA)](https://discord.gg/YXdTyCh5KF)
 
 ## 한국어 번역 정보
 


### PR DESCRIPTION
디스코드 배지가 계속 깨져있어, 새로운 배지로 수정하였습니다.

수정 후:

[![React Korea 디스코드 채널](https://img.shields.io/badge/discord-channel?style=for-the-badge&logo=discord&logoSize=100&label=React%20Korea&labelColor=%2323272F&color=%23149ECA)](https://discord.gg/YXdTyCh5KF)

React Brand Blue와 Primary gray 색상을 사용하였습니다.

https://github.com/reactjs/ko.react.dev/blob/8a588781f97df19b71e96fc5b35b9447f9ef4587/colors.js#L54

https://github.com/reactjs/ko.react.dev/blob/8a588781f97df19b71e96fc5b35b9447f9ef4587/colors.js#L14
