### PR TITLE
chore: bump `eslint-markdown` to `0.5.0`

### DIFF
--- a/.github/workflows/textlint_lint.yml
+++ b/.github/workflows/textlint_lint.yml
@@ -5,9 +5,10 @@ on:
     branches:
       - main
     paths:
-      - 'src/**/*.md'
-      - 'textlint/**/*.js'
-      - '.github/workflows/textlint_lint.yml'
+      - "src/**/*.md"
+      - "textlint/**/*.js"
+      - ".github/workflows/textlint_lint.yml"
+      - "package.json"
 
   pull_request:
     types:
@@ -15,9 +16,10 @@ on:
       - synchronize
       - reopened
     paths:
-      - 'src/**/*.md'
-      - 'textlint/**/*.js'
-      - '.github/workflows/textlint_lint.yml'
+      - "src/**/*.md"
+      - "textlint/**/*.js"
+      - ".github/workflows/textlint_lint.yml"
+      - "package.json"
 
 jobs:
   Lint:

--- a/.github/workflows/textlint_lint.yml
+++ b/.github/workflows/textlint_lint.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - main
     paths:
-      - "src/**/*.md"
-      - "textlint/**/*.js"
-      - ".github/workflows/textlint_lint.yml"
-      - "package.json"
+      - 'src/**/*.md'
+      - 'textlint/**/*.js'
+      - '.github/workflows/textlint_lint.yml'
+      - 'package.json'
 
   pull_request:
     types:
@@ -16,10 +16,10 @@ on:
       - synchronize
       - reopened
     paths:
-      - "src/**/*.md"
-      - "textlint/**/*.js"
-      - ".github/workflows/textlint_lint.yml"
-      - "package.json"
+      - 'src/**/*.md'
+      - 'textlint/**/*.js'
+      - '.github/workflows/textlint_lint.yml'
+      - 'package.json'
 
 jobs:
   Lint:

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint-plugin-import": "2.x",
     "eslint-plugin-jsx-a11y": "6.x",
     "eslint-plugin-local-rules": "link:eslint-local-rules",
-    "eslint-markdown": "^0.1.0-canary.12",
+    "eslint-markdown": "^0.5.0",
     "eslint-plugin-react": "7.x",
     "eslint-plugin-react-compiler": "^19.0.0-beta-e552027-20250112",
     "eslint-plugin-react-hooks": "^0.0.0-experimental-fabef7a6b-20221215",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3741,10 +3741,10 @@ eslint-import-resolver-typescript@^2.4.0:
     resolve "^1.22.0"
     tsconfig-paths "^3.14.1"
 
-eslint-markdown@^0.1.0-canary.12:
-  version "0.1.0-canary.12"
-  resolved "https://registry.yarnpkg.com/eslint-markdown/-/eslint-markdown-0.1.0-canary.12.tgz#755c255f254bd428e76e7cb98e10ad458c488638"
-  integrity sha512-iTEHFxLW2QumAgGEJjNb835zJtBGUvXA0JtuRzRjIzevjLlPkXwAJ9QM/33T5OWapb0sUADxDtkxoVbogvOshA==
+eslint-markdown@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-markdown/-/eslint-markdown-0.5.0.tgz#09f142af02801c87431bc491c093c9d34e6e24ea"
+  integrity sha512-EVY0viuqqPLNxo+/hcSuSsG2OhKlAi+NOzSICLZk1WqgI5OzAwGBELXnN6KoZWNp/ISzzeRtvUayavv9tlSpvg==
   dependencies:
     "@eslint/markdown" "^7.5.1"
     micromark-util-normalize-identifier "^2.0.1"


### PR DESCRIPTION
This pull request makes minor updates to the workflow configuration and development dependencies. The workflow for text linting is expanded to include `package.json` as a trigger, and the `eslint-markdown` dependency is updated to a newer version.

- **Workflow Configuration Updates:**
  * The `.github/workflows/textlint_lint.yml` workflow now also triggers on changes to `package.json`, in addition to the existing paths.

- **Dependency Updates:**
  * Upgraded the `eslint-markdown` package in `package.json` from version `^0.1.0-canary.12` to `^0.5.0`.