### PR TITLE
docs: fix duplicate particle typo in Children

### DIFF
--- a/src/content/reference/react/Children.md
+++ b/src/content/reference/react/Children.md
@@ -847,7 +847,7 @@ export default function TabSwitcher({ tabIds, getHeader, renderContent }) {
 
 `renderContent`와 같이 사용자 인터페이스의 일부를 어떻게 렌더링할지 정의하는 Prop를 *렌더링 Prop*라고 합니다. 하지만 특별한 것은 아닙니다. 단지 일반적인 함수의 Prop일 뿐입니다.
 
-렌더링 Prop은은 함수이므로 정보를 전달할 수 있습니다.
+렌더링 Prop은 함수이므로 정보를 전달할 수 있습니다.
 아래 예시에서 `RowList` 컴포넌트는 각 row의 `id`와 `index`를 `renderRow`에 렌더링 Prop로 전달하고, `index`가 짝수인 row를 강조합니다.
 
 <Sandpack>


### PR DESCRIPTION
<!--
  PR을 보내주셔서 감사합니다! 여러분과 같은 기여자들이 React를 더욱 멋지게 만듭니다!

  기존 이슈와 관련된 PR이라면, 아래에 이슈 번호를 추가해주세요.
-->

#  Children.md 조사 중복 오타 수정

<!--
  어떤 종류의 PR인지 상세 내용을 작성해주세요.
-->

  ## 변경 사항

  `src/content/reference/react/Children.md`에서 잘못 중복된 조사를 수정합니다.

  ### 수정 내용
  | 수정 전 | 수정 후 |
  | --- | --- |
  | `렌더링 Prop은은` | `렌더링 Prop은` |

  "렌더링 Prop은은 함수이므로"에서 조사 '은'이 중복으로 작성되어 있어 하나로 수정했습니다.

## 필수 확인 사항

- [x] [기여자 행동 강령 규약<sup>Code of Conduct</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CODE_OF_CONDUCT.md)
- [x] [기여 가이드라인<sup>Contributing</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md)
- [x] [공통 스타일 가이드<sup>Universal Style Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [번역을 위한 모범 사례<sup>Best Practices for Translation</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [번역 용어 정리<sup>Translate Glossary</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [`textlint` 가이드<sup>Textlint Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint-guide.md)
- [x] [맞춤법 검사<sup>Spelling Check</sup>](https://nara-speller.co.kr/speller/)

## 선택 확인 사항

- [ ] 번역 초안 작성<sup>Draft Translation</sup>
- [ ] 리뷰 반영<sup>Resolve Reviews</sup>
