### PR TITLE
docs: fix typo in createRoot reference (duplicate 은)

### DIFF
--- a/src/content/reference/react-dom/client/createRoot.md
+++ b/src/content/reference/react-dom/client/createRoot.md
@@ -156,7 +156,7 @@ root.render(<App />);
 <html>
   <head><title>My app</title></head>
   <body>
-    <!-- 이것은은 DOM 노드입니다. -->
+    <!-- 이것은 DOM 노드입니다. -->
     <div id="root"></div>
   </body>
 </html>


### PR DESCRIPTION
# `createRoot` 레퍼런스 오타 수정

`createRoot` 레퍼런스 페이지의 코드 예시 내 HTML 주석에서 조사 "은"이 중복 기재된 오타를 수정했습니다.

## 변경 내용

**파일:** `src/content/reference/react-dom/client/createRoot.md`

```html
<!-- Before -->
<!-- 이것은은 DOM 노드입니다. -->

<!-- After -->
<!-- 이것은 DOM 노드입니다. -->
```

## 필수 확인 사항

- [x] [기여자 행동 강령 규약<sup>Code of Conduct</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CODE_OF_CONDUCT.md)
- [x] [기여 가이드라인<sup>Contributing</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md)
- [x] [공통 스타일 가이드<sup>Universal Style Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [번역을 위한 모범 사례<sup>Best Practices for Translation</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [번역 용어 정리<sup>Translate Glossary</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [`textlint` 가이드<sup>Textlint Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint-guide.md)
- [x] [맞춤법 검사<sup>Spelling Check</sup>](https://nara-speller.co.kr/speller/)

## 선택 확인 사항

- [ ] 번역 초안 작성<sup>Draft Translation</sup>
- [ ] 리뷰 반영<sup>Resolve Reviews</sup>
