### PR TITLE
docs: fix duplicate phrasing typo in renderToReadableStream

### DIFF
--- a/src/content/reference/react-dom/server/renderToReadableStream.md
+++ b/src/content/reference/react-dom/server/renderToReadableStream.md
@@ -47,7 +47,7 @@ async function handler(request) {
 
 #### 매개변수 {/*parameters*/}
 
-* `reactNode`: 사용자가 HTML로 렌더링하고 하고자하는 React node입니다. `<App />`같은 JSX 요소가 그 예시입니다. reactNode 인자는 문서 전체를 표현할 수 있는 것이어야하며, 따라서 `App` 컴포넌트는 `<html>`에 렌더링됩니다.
+* `reactNode`: 사용자가 HTML로 렌더링하고자 하는 React node입니다. `<App />`같은 JSX 요소가 그 예시입니다. reactNode 인자는 문서 전체를 표현할 수 있는 것이어야하며, 따라서 `App` 컴포넌트는 `<html>`에 렌더링됩니다.
 
 * `options`**(선택사항)**: 스트리밍 옵션을 지정할 수 있는 객체입니다.
   * `bootstrapScriptContent`**(선택사항)**: 지정될 경우, 해당 문자열은 `<script>` 태그에 인라인 형식으로 추가됩니다.


### PR DESCRIPTION
<!--
  PR을 보내주셔서 감사합니다! 여러분과 같은 기여자들이 React를 더욱 멋지게 만듭니다!

  기존 이슈와 관련된 PR이라면, 아래에 이슈 번호를 추가해주세요.
-->

# renderToReadableStream 중복 기재되었던 연결 어미 표현 교정


<img width="576" alt="스크린샷 2026-06-06 오후 7 21 11" src="https://github.com/user-attachments/assets/3de09958-296d-4a6d-94f4-c7d034af51b8" />

<img width="535" alt="스크린샷 2026-06-06 오후 7 23 57" src="https://github.com/user-attachments/assets/b83480c5-a845-41e4-8941-9392a181a49c" />

```diff
- * `reactNode`: 사용자가 HTML로 렌더링하고 하고자하는 React node입니다.
+ * `reactNode`: 사용자가 HTML로 렌더링하고자 하는 React node입니다.
```

`renderToReadableStream` 문서의 불필요하게 중복 기재되었던 연결 어미 표현을 보다 자연스럽고 올바른 문장 표현으로 교정하였습니다.


## 필수 확인 사항

- [x] [기여자 행동 강령 규약<sup>Code of Conduct</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CODE_OF_CONDUCT.md)
- [x] [기여 가이드라인<sup>Contributing</sup>](https://github.com/reactjs/ko.react.dev/blob/main/CONTRIBUTING.md)
- [x] [공통 스타일 가이드<sup>Universal Style Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/universal-style-guide.md)
- [x] [번역을 위한 모범 사례<sup>Best Practices for Translation</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/best-practices-for-translation.md)
- [x] [번역 용어 정리<sup>Translate Glossary</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/translate-glossary.md)
- [x] [`textlint` 가이드<sup>Textlint Guide</sup>](https://github.com/reactjs/ko.react.dev/blob/main/wiki/textlint-guide.md)
- [x] [맞춤법 검사<sup>Spelling Check</sup>](https://nara-speller.co.kr/speller/)

## 선택 확인 사항

- [ ] 번역 초안 작성<sup>Draft Translation</sup>
- [ ] 리뷰 반영<sup>Resolve Reviews</sup>
